### PR TITLE
PLP-14: Add Bootstrap Accordion

### DIFF
--- a/apps/drupal/particle.info.yml
+++ b/apps/drupal/particle.info.yml
@@ -43,6 +43,7 @@ component-libraries:
     paths:
       - ../../source/_patterns/03-organisms
       - ../../source/_patterns/03-organisms/article
+      - ../../source/_patterns/03-organisms/accordion
       - ../../source/_patterns/03-organisms/card-grid
   templates:
     paths:

--- a/apps/pl/pattern-lab/config/config.yml
+++ b/apps/pl/pattern-lab/config/config.yml
@@ -74,6 +74,7 @@ plugins:
         paths:
           - ../../../source/_patterns/03-organisms
           - ../../../source/_patterns/03-organisms/article
+          - ../../../source/_patterns/03-organisms/accordion
           - ../../../source/_patterns/03-organisms/card-grid
       templates:
         paths:

--- a/source/_patterns/02-molecules/card/_card.twig
+++ b/source/_patterns/02-molecules/card/_card.twig
@@ -35,11 +35,13 @@
 ]) | sort | join(' ') | trim %}
 
 <div class="{{ classes }}">
-  {% if card_header %}
-    <div class="card-header">
-      {{ card_header }}
-    </div>
-  {% endif %}
+  {% block card_header %}
+    {% if card_header %}
+      <div class="card-header">
+        {{ card_header }}
+      </div>
+    {% endif %}
+  {% endblock card_header %}
 
   {% if card_image_location == 'top' %}
     {% block card_image_top %}
@@ -65,8 +67,8 @@
     {% set body_class = 'card-body' %}
   {% endif %}
 
-  <div class="{{ body_class }}">
-    {% block card_body %}
+  {% block card_body %}
+    <div class="{{ body_class }}">
       <h4 class="card-title">{{ card_title }}</h4>
       {% if card_subtitle %}
         <h6 class="card-subtitle mb-2 text-muted">{{ card_subtitle }}</h6>
@@ -80,8 +82,8 @@
       {% if button %}
         {% include "@atoms/button/_button.twig" with button %}
       {% endif %}
-    {% endblock %}
-  </div>
+    </div>
+  {% endblock %}
 
   {% if list %}
     {% include '@atoms/list-group/_list-group.twig' with list %}

--- a/source/_patterns/03-organisms/accordion/_accordion.scss
+++ b/source/_patterns/03-organisms/accordion/_accordion.scss
@@ -1,0 +1,9 @@
+// All component Sass needs non-printing base config
+@import '../../00-base/variables';
+
+// Accordion contains both Bootstrap Card and Collapse.
+// To change default bootstrap variables, SEE ~bootstrap/scss/variables
+// Add bootstrap variables here
+//$card-border-width: 1px;
+
+// Add custom code here

--- a/source/_patterns/03-organisms/accordion/_accordion.twig
+++ b/source/_patterns/03-organisms/accordion/_accordion.twig
@@ -1,0 +1,38 @@
+{#
+  Accordion!
+
+  accordion_id: Integer: A unique numerical ID for the accordion.
+  accordion_card_list: Array: A list of cards and their values.
+
+  card_header: String: The header on the card.
+  card_text: String: The text on the card.
+  card_expanded: String: The default collapse state on the card.
+
+  Accordions combine Bootstrap's Card and Collapse. See below for more details:
+
+  * https://getbootstrap.com/docs/4.0/components/collapse/
+  * https://getbootstrap.com/docs/4.0/components/card/
+#}
+
+<div id="{{ 'accordion-' ~ accordion_id }}" role="tablist">
+  {% for card in accordion_card_list %}
+    {% embed '@molecules/card/_card.twig' %}
+      {% block card_header %}
+        <div class="card-header" role="tab" id="{{ 'heading-' ~ loop.index }}">
+          <h5 class="mb-0">
+            <a data-toggle="collapse" href="{{ '#collapse-' ~ loop.index }}" aria-expanded="{{ card_expanded }}" aria-controls="{{ 'collapse-' ~ loop.index }}">
+              {{ card.card_header }}
+            </a>
+          </h5>
+        </div>
+      {% endblock card_header %}
+      {% block card_body %}
+        <div id="{{ 'collapse-' ~ loop.index }}" class="collapse" role="tabpanel" aria-labelledby="{{ 'heading-' ~ loop.index }}" data-parent="{{ 'accordion-' ~ accordion_id }}">
+          <div class="card-body">
+            {{ card.card_text }}
+          </div>
+        </div>
+        {% endblock card_body %}
+    {% endembed %}
+  {% endfor %}
+</div>

--- a/source/_patterns/03-organisms/accordion/demo/accordions.twig
+++ b/source/_patterns/03-organisms/accordion/demo/accordions.twig
@@ -1,0 +1,9 @@
+{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+  {% block column_1 %}
+
+    <h1>Accordion</h1>
+    <p class="lead">Accordions make usee of Bootstrap's <a href="https://getbootstrap.com/docs/4.0/components/collapse/" target="_blank">Collapse</a> with the card component. Default collapse behavior is extended to create an accordion.</p>
+    {% include '@organisms/accordion/_accordion.twig' with accordion_1 %}
+
+  {% endblock %}
+{% endembed %}

--- a/source/_patterns/03-organisms/accordion/demo/accordions.yml
+++ b/source/_patterns/03-organisms/accordion/demo/accordions.yml
@@ -1,0 +1,12 @@
+accordion_1:
+  accordion_id: 1
+  accordion_card_list:
+    - card_header: 'Collapsible Group Item #1'
+      card_text: 'Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven''t heard of them accusamus labore sustainable VHS.'
+      card_expanded: FALSE
+    - card_header: 'Collapsible Group Item #2'
+      card_text: 'Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven''t heard of them accusamus labore sustainable VHS.'
+      card_expanded: FALSE
+    - card_header: 'Collapsible Group Item #3'
+      card_text: 'Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven''t heard of them accusamus labore sustainable VHS.'
+      card_expanded: FALSE

--- a/source/_patterns/03-organisms/accordion/index.js
+++ b/source/_patterns/03-organisms/accordion/index.js
@@ -1,0 +1,21 @@
+/**
+ * Accordion
+ */
+
+import 'bootstrap/js/src/collapse';
+
+// Module dependencies
+import 'base';
+import 'atoms/button';
+import 'molecules/card';
+
+// Module styles
+import './_accordion.scss';
+
+export const name = 'accordion';
+
+export function disable() {}
+
+export function enable() {}
+
+export default enable;

--- a/source/design-system.js
+++ b/source/design-system.js
@@ -13,6 +13,7 @@ import * as icon from 'atoms/icon';
 import * as listGroup from 'atoms/list-group';
 import * as card from 'molecules/card';
 import * as jumbotron from 'molecules/jumbotron';
+import * as accordion from 'organisms/accordion';
 import * as article from 'organisms/article';
 
 export default {
@@ -26,5 +27,6 @@ export default {
   listGroup,
   card,
   jumbotron,
+  accordion,
   article,
 };


### PR DESCRIPTION
This PR adds the Card Accordion version of Bootstrap's Collapse. Some card work had to be refactored to allow for Accordions. Mainly moving content of card_header and card_body inside of blocks so they can be overridden completely.