### PR TITLE
Feature/v10/194 cleanup tasks

### DIFF
--- a/source/_data/imageStyles.yaml
+++ b/source/_data/imageStyles.yaml
@@ -10,8 +10,8 @@ imageStyles:
     height: 400
   medium:
     width: 800
-  large:
-    width: 1600
   carousel:
     width: 1110
     height: 400
+  large:
+    width: 1110

--- a/source/_patterns/01-atoms/alert/_alert.twig
+++ b/source/_patterns/01-atoms/alert/_alert.twig
@@ -1,8 +1,6 @@
 {#
   Alert!
 
-  Documenting Alerts from Bootstrap.
-
   type: String: status | warning | error: The type of error to display.
   alert_degree: String (optional): The degree of error. Set via Type for Accessibility.
   alert_title: String: The heading value of the Alert.
@@ -27,6 +25,7 @@
   'alert-dismissible',
   'fade',
   'show',
+  alert_other_classes,
 ] | sort | join(' ') | trim %}
 
 {% set alert_degree = ( type == 'error' ? 'role=alert' : 'aria-live=polite' ) %}

--- a/source/_patterns/01-atoms/alert/demo/alerts.twig
+++ b/source/_patterns/01-atoms/alert/demo/alerts.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
 
     {% include '@atoms/alert/_alert.twig' with alert_status %}
@@ -10,4 +12,4 @@
     {% include '@atoms/alert/_alert.twig' with alert_info %}
 
   {% endblock %}
-{% endembed %}
+

--- a/source/_patterns/01-atoms/badge/_badge.twig
+++ b/source/_patterns/01-atoms/badge/_badge.twig
@@ -1,5 +1,6 @@
 {#
   Badge!
+
   badge_element: String: span|a Choose the element type for your badge. If you use an <a> tag make sure to enter a value for badge_link.
   badge_pill: Boolean: TRUE|FALSE Make badges more rounded.
   badge_color: String: primary|secondary|success|danger|warning|info|light|dark The color of the badge.
@@ -10,16 +11,17 @@
 {% set badge_element = badge_element | default('span') %}
 {% set badge_color = badge_color | default('primary') %}
 
-{% set classes = [
+{% set badge_classes = [
   'badge',
   badge_pill ? 'badge-pill',
   badge_color ? 'badge-' ~ badge_color,
-] | sort | join(' ') | trim ~ ' ' ~ badge_other_classes %}
+  badge_other_classes,
+] | sort | join(' ') | trim %}
 
 {% if badge_link %}
   {% set badge_link = 'href="' ~ badge_link ~ '"' %}
 {% endif %}
 
-<{{ badge_element }} {{ badge_link }} class="{{ classes }}">
+<{{ badge_element }} {{ badge_link }} class="{{ badge_classes }}">
   {{ badge_text }}
 </{{ badge_element }}>

--- a/source/_patterns/01-atoms/badge/_badge.twig
+++ b/source/_patterns/01-atoms/badge/_badge.twig
@@ -14,12 +14,12 @@
   'badge',
   badge_pill ? 'badge-pill',
   badge_color ? 'badge-' ~ badge_color,
-] | join (' ') %}
+] | sort | join(' ') | trim ~ ' ' ~ badge_other_classes %}
 
 {% if badge_link %}
   {% set badge_link = 'href="' ~ badge_link ~ '"' %}
 {% endif %}
 
-<{{ badge_element }} {{ badge_link }}class="{{ classes }}">
+<{{ badge_element }} {{ badge_link }} class="{{ classes }}">
   {{ badge_text }}
 </{{ badge_element }}>

--- a/source/_patterns/01-atoms/badge/demo/badges.twig
+++ b/source/_patterns/01-atoms/badge/demo/badges.twig
@@ -9,7 +9,7 @@
       text_color: 'light',
       button: {
         button_link: 'https://getbootstrap.com/docs/4.0/components/badge/',
-      }
+      },
     } %}
     <div class="mb-3">
       <h1>Badge Sizes</h1>

--- a/source/_patterns/01-atoms/badge/demo/badges.twig
+++ b/source/_patterns/01-atoms/badge/demo/badges.twig
@@ -1,87 +1,86 @@
-<div class="container">
-  {% embed '@atoms/grid/_grid-1-up.twig' %}
-    {% block column_1 %}
-      <h1>Badges</h1>
-      {% include '@molecules/card/_card-helper.twig' with {
-        card_text: badges_helper,
-        card_background: 'secondary',
-        text_color: 'light',
-        button: {
-          button_link: 'https://getbootstrap.com/docs/4.0/components/badge/',
-        }
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
+  {% block column_1 %}
+    <h1>Badges</h1>
+    {% include '@molecules/card/_card-helper.twig' with {
+      card_text: badges_helper,
+      card_background: 'secondary',
+      text_color: 'light',
+      button: {
+        button_link: 'https://getbootstrap.com/docs/4.0/components/badge/',
+      }
+    } %}
+    <div class="mb-3">
+      <h1>Badge Sizes</h1>
+      <p>Note: Badges scale to match the size of the immediate parent element </p>
+      {% for i in 1..5 %}
+        <h{{ i }}>
+        {% include '@atoms/badge/_badge.twig' with {
+          badge_text: 'Badge',
+          badge_color: 'primary',
+        } %}
+        </h{{ i }}>
+      {% endfor %}
+    </div>
+
+    <div class="mb-3">
+      <h1>Badge Button</h1>
+      {% embed '@atoms/button/_button.twig' with {
+        button_color: 'primary',
+        button_text: 'Notifications',
       } %}
-      <div class="mb-3">
-        <h1>Badge Sizes</h1>
-        <p>Note: Badges scale to match the size of the immediate parent element </p>
-        {% for i in 1..5 %}
-          <h{{ i }}>
+        {% block right %}
           {% include '@atoms/badge/_badge.twig' with {
-            badge_text: 'Badge',
+            badge_text: '4',
+            badge_color: 'light',
+          } %}
+        {% endblock right %}
+      {% endembed %}
+
+      {% embed '@atoms/button/_button-outline.twig' with {
+        button_color: 'primary',
+        button_text: 'Notifications',
+      } %}
+        {% block right %}
+          {% include '@atoms/badge/_badge.twig' with {
+            badge_text: '4',
             badge_color: 'primary',
           } %}
-          </h{{ i }}>
-        {% endfor %}
-      </div>
+        {% endblock right %}
+      {% endembed %}
+    </div>
 
-      <div class="mb-3">
-        <h1>Badge Button</h1>
-        {% embed '@atoms/button/_button.twig' with {
-          button_color: 'primary',
-          button_text: 'Notifications',
+    <div class="mb3">
+      <h1>Badge Colors</h1>
+      {% for name, rgb in scssColors %}
+        {% include '@atoms/badge/_badge.twig' with {
+          badge_color: name,
+          badge_text: name,
         } %}
-          {% block right %}
-            {% include '@atoms/badge/_badge.twig' with {
-              badge_text: '4',
-              badge_color: 'light',
-            } %}
-          {% endblock right %}
-        {% endembed %}
+      {% endfor %}
+    </div>
 
-        {% embed '@atoms/button/_button-outline.twig' with {
-          button_color: 'primary',
-          button_text: 'Notifications',
+    <div class="mb-3">
+      <h1>Pill Badges</h1>
+      {% for name, rgb in scssColors %}
+        {% include '@atoms/badge/_badge.twig' with {
+          badge_color: name,
+          badge_text: name,
+          badge_pill: TRUE,
         } %}
-          {% block right %}
-            {% include '@atoms/badge/_badge.twig' with {
-              badge_text: '4',
-              badge_color: 'primary',
-            } %}
-          {% endblock right %}
-        {% endembed %}
-      </div>
+      {% endfor %}
+    </div>
 
-      <div class="mb3">
-        <h1>Badge Colors</h1>
-        {% for name, rgb in scssColors %}
-          {% include '@atoms/badge/_badge.twig' with {
-            badge_color: name,
-            badge_text: name,
-          } %}
-        {% endfor %}
-      </div>
-
-      <div class="mb-3">
-        <h1>Pill Badges</h1>
-        {% for name, rgb in scssColors %}
-          {% include '@atoms/badge/_badge.twig' with {
-            badge_color: name,
-            badge_text: name,
-            badge_pill: TRUE,
-          } %}
-        {% endfor %}
-      </div>
-
-      <div class="mb-3">
-        <h1>Badge Links</h1>
-        {% for name, rgb in scssColors %}
-          {% include '@atoms/badge/_badge.twig' with {
-            badge_color: name,
-            badge_text: name,
-            badge_element: 'a',
-            badge_link: 'https://github.com/phase2/pattern-lab-starter',
-          } %}
-        {% endfor %}
-      </div>
-    {% endblock column_1 %}
-  {% endembed %}
-</div>
+    <div class="mb-3">
+      <h1>Badge Links</h1>
+      {% for name, rgb in scssColors %}
+        {% include '@atoms/badge/_badge.twig' with {
+          badge_color: name,
+          badge_text: name,
+          badge_element: 'a',
+          badge_link: 'https://github.com/phase2/pattern-lab-starter',
+        } %}
+      {% endfor %}
+    </div>
+  {% endblock column_1 %}

--- a/source/_patterns/01-atoms/badge/demo/badges.twig
+++ b/source/_patterns/01-atoms/badge/demo/badges.twig
@@ -79,7 +79,7 @@
           badge_color: name,
           badge_text: name,
           badge_element: 'a',
-          badge_link: 'https://github.com/phase2/pattern-lab-starter',
+          badge_link: 'https://github.com/phase2/particle',
         } %}
       {% endfor %}
     </div>

--- a/source/_patterns/01-atoms/branding/demo/brandings.twig
+++ b/source/_patterns/01-atoms/branding/demo/brandings.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
     <h1>Branding Examples</h1>
     <p class="lead">Different applications of a branding block.</p>
@@ -25,4 +27,3 @@
 
     {% endembed %}
   {% endblock column_1 %}
-{% endembed %}

--- a/source/_patterns/01-atoms/breadcrumb/demo/breadcrumbs.twig
+++ b/source/_patterns/01-atoms/breadcrumb/demo/breadcrumbs.twig
@@ -1,12 +1,16 @@
-<div class="container">
-  <h1>Breadcrumbs</h1>
-  <p class="lead">Indicate the current page's location within a navigational hierarchy that automatically adds separators via CSS. Breadcrumbs take an array and render each as a list item. You can set the items in <code>breadcrumbs.yml</code>.
-    Separators are automatically added in CSS through <code>::before</code> and  <code>::content</code>.</p>
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
 
-  {% include '@atoms/breadcrumb/_breadcrumb.twig' with demo_1 %}
+  {% block column_1 %}
 
-  {% include '@atoms/breadcrumb/_breadcrumb.twig' with demo_2 %}
+    <h1>Breadcrumbs</h1>
+    <p class="lead">Indicate the current page's location within a navigational hierarchy that automatically adds separators via CSS. Breadcrumbs take an array and render each as a list item. You can set the items in <code>breadcrumbs.yml</code>.
+      Separators are automatically added in CSS through <code>::before</code> and  <code>::content</code>.</p>
 
-  {% include '@atoms/breadcrumb/_breadcrumb.twig' with demo_3 %}
+    {% include '@atoms/breadcrumb/_breadcrumb.twig' with demo_1 %}
 
-</div>
+    {% include '@atoms/breadcrumb/_breadcrumb.twig' with demo_2 %}
+
+    {% include '@atoms/breadcrumb/_breadcrumb.twig' with demo_3 %}
+
+  {% endblock column_1 %}

--- a/source/_patterns/01-atoms/button/_button.twig
+++ b/source/_patterns/01-atoms/button/_button.twig
@@ -40,7 +40,7 @@
 {% set button_attributes = [
   button_active ? 'aria-pressed="true"',
   button_toggle ? 'data-toggle="' ~ button_toggle ~ '"',
-  button_link ? 'href="' ~ button_link ~ '"',
+  button_link ? 'href=' ~ button_link,
   button_value ? 'value="' ~ button_value ~ '"',
   button_id ? 'id="' ~ button_id ~ '"',
   button_disabled ? 'disabled',

--- a/source/_patterns/01-atoms/button/_button.twig
+++ b/source/_patterns/01-atoms/button/_button.twig
@@ -1,5 +1,6 @@
 {#
   Button!
+
   button_element: String: button|a|input choose the element type for your button.
   button_type: String: the html 'type' attribute.
   button_outline: Boolean: True|False, remove all background colors and images from a button.
@@ -16,6 +17,7 @@
   button_disabled: Boolean: True|False set button to appear disabled.
   button_other_attributes: String: Other attributes not specified in the template.
   button_text: String: Display text on the button.
+
   See https://getbootstrap.com/docs/4.0/components/buttons/ for more details
 #}
 
@@ -25,25 +27,27 @@
   {% set button_type = 'type="' ~ button_type | default('button') ~ '"' %}
 {% endif %}
 
-{% set classes = [
+{% set button_classes = [
   buttonless_dropdown ? '' : 'btn',
   button_color ? 'btn-' ~ button_color,
   button_outline ? 'btn-outline-' ~ button_color,
   button_size ? 'btn-' ~ button_size,
   button_block ? 'btn-block',
   button_active ? 'active',
-] | sort | join(' ') | trim ~ ' ' ~ button_other_classes %}
+  button_other_classes,
+] | sort | join(' ') | trim %}
 
-{% set attributes  = [
+{% set button_attributes = [
   button_active ? 'aria-pressed="true"',
   button_toggle ? 'data-toggle="' ~ button_toggle ~ '"',
   button_link ? 'href="' ~ button_link ~ '"',
   button_value ? 'value="' ~ button_value ~ '"',
   button_id ? 'id="' ~ button_id ~ '"',
   button_disabled ? 'disabled',
-] | sort | join(' ') | trim ~ ' ' ~ button_other_attributes %}
+  button_other_attributes,
+] | sort | join(' ') | trim %}
 
-<{{ button_element }} {{ button_type }} class="{{ classes }}" {{ attributes }}>
+<{{ button_element }} {{ button_type }} class="{{ button_classes }}" {{ button_attributes }}>
   {{ button_text }}
   {% block right %}{% endblock right %}
 </{{ button_element }}>

--- a/source/_patterns/01-atoms/button/demo/buttons.twig
+++ b/source/_patterns/01-atoms/button/demo/buttons.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
     <h1>Buttons</h1>
     {% include '@molecules/card/_card-helper.twig' with {
@@ -71,4 +73,3 @@
       {% include '@atoms/button/_button.twig' with toggleable %}
     </div>
   {% endblock column_1 %}
-{% endembed %}

--- a/source/_patterns/01-atoms/dropdown/_dropdown.twig
+++ b/source/_patterns/01-atoms/dropdown/_dropdown.twig
@@ -1,5 +1,6 @@
 {#
   Dropdown!
+
   dropdown_element: String: div|li|ul: Choose the html element of the dropdown.
   dropdown_button: Boolean: True|False: Choose whether the dropdown will be a button element or not.
   dropdown_other_classes: String: Allows use of other bootstrap utility classes.
@@ -14,8 +15,10 @@
   dropdown_menu_items: Array: An array of menu items.
   dropdown_menu_item_disabled: Boolean: True|False: Set an individual menu option as disabled.
   dropdown_menu_item_text: String: Set the text of an individual menu item.
+
   See https://getbootstrap.com/docs/4.0/components/dropdowns/ fro more details
 #}
+
 {% set dropdown_element = dropdown_element | default('div') %}
 
 {% if dropdown_button %}
@@ -24,15 +27,16 @@
   {% set dropdown_class = 'dropdown' %}
 {% endif %}
 
-{% set classes = [
+{% set dropdown_classes = [
   dropdown_class,
   dropup ? 'dropup',
-] | sort | join(' ') | trim ~ ' ' ~ dropdown_other_classes %}
+  dropdown_other_classes,
+] | sort | join(' ') | trim %}
 
 {% set dropdown_menu_element = dropdown_menu_element | default('a') %}
 {% set dropdown_menu_aria_label = button_id ? 'aria-labelledby="' ~ button_id ~ '"' %}
 
-<{{ dropdown_element }} class="{{ classes }}">
+<{{ dropdown_element }} class="{{ dropdown_classes }}">
   {% if dropdown_split %}
     {% include '@atoms/button/_button-dropdown-split.twig' %}
   {% else %}

--- a/source/_patterns/01-atoms/dropdown/demo/dropdowns.twig
+++ b/source/_patterns/01-atoms/dropdown/demo/dropdowns.twig
@@ -1,5 +1,6 @@
-<div class="container">
-  {% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
     {% block column_1 %}
 
       <h1>Dropdowns</h1>
@@ -198,5 +199,3 @@
       </div>
 
     {% endblock column_1 %}
-  {% endembed %}
-</div>

--- a/source/_patterns/01-atoms/grid/demo/grid-demo.twig
+++ b/source/_patterns/01-atoms/grid/demo/grid-demo.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
 
     <h1>Grid Demo</h1>
@@ -57,4 +59,3 @@
     {% endembed %}
 
   {% endblock column_1 %}
-{% endembed %}

--- a/source/_patterns/01-atoms/icon/demo/icons.twig
+++ b/source/_patterns/01-atoms/icon/demo/icons.twig
@@ -1,107 +1,106 @@
-<div class="container">
-  {% embed '@atoms/_grid-1-up.twig' %}
-    {% block column_1 %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
 
-      <h1>Icons</h1>
+  {% block column_1 %}
 
-      <div class="card text-light bg-secondary mb-3">
-        <div class="card-body">
-          <h4 class="card-title">Use</h4>
-          <p class="card-text">An icon font is generated from all SVGs within
-            the folder <code>@atoms/icon/svg/</code>. Simply add the <code>icon--name</code>
-            class to any element to add an icon. For instance, if there is a
-            <code>search.svg</code> within the svg folder, you can add a search
-            icon like this: <code>&#x3C;i class=&#x22;icon--search&#x22;&#x3E;&#x3C;/i&#x3E;</code>
-            which will result in: <i class="icon--search"></i>.</p>
-          <p>A Sass mixin is also provided that gives greater flexibility. To
-            add a search icon as a pseudo element to any element, simply <code>@include
-              icon(search);</code>. Besides icon name, this mixin includes
-            parameters for pseudo position, text-replacement, size, color, and
-            block display. See <code>@atoms/icon/scss/_icon-mixins.scss</code>
-            for more detail.</p>
-          <h4>Considerations</h4>
-          <ul>
-            <li>It is recommended that all SVGs be on the same size canvas (512px x 512px). All glyphs are scaled up to the size of the largest glyph otherwise.</li>
-            <li>Adding new SVGs to the folder requires restarting the webpack dev server.</li>
-            <li>Font icons inherit the color of their parent text.</li>
-            <li>The generated font named <strong>{{ scssIcons.fontname }}</strong> will be <a href="https://github.com/webpack-contrib/url-loader" target="_blank">base64 inlined</a> into the output CSS.</li>
-          </ul>
-        </div>
+    <h1>Icons</h1>
+
+    <div class="card text-light bg-secondary mb-3">
+      <div class="card-body">
+        <h4 class="card-title">Use</h4>
+        <p class="card-text">An icon font is generated from all SVGs within
+          the folder <code>@atoms/icon/svg/</code>. Simply add the <code>icon--name</code>
+          class to any element to add an icon. For instance, if there is a
+          <code>search.svg</code> within the svg folder, you can add a search
+          icon like this: <code>&#x3C;i class=&#x22;icon--search&#x22;&#x3E;&#x3C;/i&#x3E;</code>
+          which will result in: <i class="icon--search"></i>.</p>
+        <p>A Sass mixin is also provided that gives greater flexibility. To
+          add a search icon as a pseudo element to any element, simply <code>@include
+            icon(search);</code>. Besides icon name, this mixin includes
+          parameters for pseudo position, text-replacement, size, color, and
+          block display. See <code>@atoms/icon/scss/_icon-mixins.scss</code>
+          for more detail.</p>
+        <h4>Considerations</h4>
+        <ul>
+          <li>It is recommended that all SVGs be on the same size canvas (512px x 512px). All glyphs are scaled up to the size of the largest glyph otherwise.</li>
+          <li>Adding new SVGs to the folder requires restarting the webpack dev server.</li>
+          <li>Font icons inherit the color of their parent text.</li>
+          <li>The generated font named <strong>{{ scssIcons.fontname }}</strong> will be <a href="https://github.com/webpack-contrib/url-loader" target="_blank">base64 inlined</a> into the output CSS.</li>
+        </ul>
       </div>
+    </div>
 
-      <div class="d-flex align-items-center flex-wrap" style="min-height: 10rem;">
-        {% for icon in scssIcons.icons %}
-          <div class="col p-3 text-center">
-            <i class="{{ scssIcons.prefix }}{{ icon }}"></i>
-            <i class="{{ scssIcons.prefix }}{{ icon }} text-primary" style="font-size: 1.5rem;"></i>
-            <i class="{{ scssIcons.prefix }}{{ icon }} bg-dark text-white" style="font-size: 2rem;"></i>
-            <p class="w-100 pt-3" style="white-space: nowrap;"><code>{{ icon }}</code></p>
-          </div>
-        {% endfor %}
-      </div>
-
-
-      <div class="card text-light bg-secondary mb-3">
-        <div class="card-body">
-          <h4 class="card-title">Font Awesome</h4>
-          <p class="card-text"><a href="http://fontawesome.io/examples/" target="_blank">Font Awesome</a> icons are also available for use inside patterns.</p>
-          <p>These can be easily added to inline elements (we recommend using <b>span</b> or <b>i</b> tags) with two classes: <code>fa</code> and <code>fa-icon-name</code>.</p>
-
-          <p>Font awesome icons can also be implemented in Sass, in just two lines:
-            <code>@include fa-icon();</code>
-            <code>content: $fa-icon-name;</code>
-          </p>
-
-          <p>See _icon.scss for an example of how the Sass approach works.</p>
-
-          <p>There are currently 675 icons available from <a href="http://fontawesome.io/examples/" target="_blank">Font Awesome</a>, sky's the limit.</p>
-        </div>
-      </div>
-
-      <div class="d-flex align-items-center flex-wrap" style="min-height: 10rem;">
+    <div class="d-flex align-items-center flex-wrap" style="min-height: 10rem;">
+      {% for icon in scssIcons.icons %}
         <div class="col p-3 text-center">
-          <i class="fa fa-battery-full"></i>
-          <i class="fa fa-battery-full text-primary" style="font-size: 1.5rem;"></i>
-          <i class="fa fa-battery-full bg-dark text-white" style="font-size: 2rem;"></i>
-          <p class="w-100 pt-3" style="white-space: nowrap;"><code>fa fa-battery-full</code></p>
+          <i class="{{ scssIcons.prefix }}{{ icon }}"></i>
+          <i class="{{ scssIcons.prefix }}{{ icon }} text-primary" style="font-size: 1.5rem;"></i>
+          <i class="{{ scssIcons.prefix }}{{ icon }} bg-dark text-white" style="font-size: 2rem;"></i>
+          <p class="w-100 pt-3" style="white-space: nowrap;"><code>{{ icon }}</code></p>
         </div>
+      {% endfor %}
+    </div>
 
-        <div class="col p-3 text-center">
-          <i class="fa fa-moon-o"></i>
-          <i class="fa fa-moon-o text-primary" style="font-size: 1.5rem;"></i>
-          <i class="fa fa-moon-o bg-dark text-white" style="font-size: 2rem;"></i>
-          <p class="w-100 pt-3" style="white-space: nowrap;"><code>fa fa-moon-o</code></p>
-        </div>
 
-        <div class="col p-3 text-center">
-          <i class="fa fa-medkit"></i>
-          <i class="fa fa-medkit text-primary" style="font-size: 1.5rem;"></i>
-          <i class="fa fa-medkit bg-dark text-white" style="font-size: 2rem;"></i>
-          <p class="w-100 pt-3" style="white-space: nowrap;"><code>fa fa-medkit</code></p>
-        </div>
+    <div class="card text-light bg-secondary mb-3">
+      <div class="card-body">
+        <h4 class="card-title">Font Awesome</h4>
+        <p class="card-text"><a href="http://fontawesome.io/examples/" target="_blank">Font Awesome</a> icons are also available for use inside patterns.</p>
+        <p>These can be easily added to inline elements (we recommend using <b>span</b> or <b>i</b> tags) with two classes: <code>fa</code> and <code>fa-icon-name</code>.</p>
 
-        <div class="col p-3 text-center" style="max-width: 240px;">
-          <i class="fontawesome-example"></i>
-          <i class="fontawesome-example text-primary" style="font-size: 1.5rem;"></i>
-          <i class="fontawesome-example bg-dark text-white" style="font-size: 2rem;"></i>
-          <p class="w-100 pt-3" style="white-space: nowrap; display: flex; flex-direction: column;"><code>@include fa-icon();</code><code>content: $fa-var-train;</code></p>
-        </div>
+        <p>Font awesome icons can also be implemented in Sass, in just two lines:
+          <code>@include fa-icon();</code>
+          <code>content: $fa-icon-name;</code>
+        </p>
 
-        <div class="col p-3 text-center" style="max-width: 240px;">
-          <i class="fontawesome-example2"></i>
-          <i class="fontawesome-example2 text-primary" style="font-size: 1.5rem;"></i>
-          <i class="fontawesome-example2 bg-dark text-white" style="font-size: 2rem;"></i>
-          <p class="w-100 pt-3" style="white-space: nowrap; display: flex; flex-direction: column;"><code>@include fa-icon();</code><code>content: $fa-var-compass;</code></p>
-        </div>
+        <p>See _icon.scss for an example of how the Sass approach works.</p>
 
-        <div class="col p-3 text-center" style="max-width: 240px;">
-          <i class="fontawesome-example3"></i>
-          <i class="fontawesome-example3 text-primary" style="font-size: 1.5rem;"></i>
-          <i class="fontawesome-example3 bg-dark text-white" style="font-size: 2rem;"></i>
-          <p class="w-100 pt-3" style="white-space: nowrap; display: flex; flex-direction: column;"><code>@include fa-icon();</code><code>content: $fa-var-apple;</code></p>
-        </div>
+        <p>There are currently 675 icons available from <a href="http://fontawesome.io/examples/" target="_blank">Font Awesome</a>, sky's the limit.</p>
+      </div>
+    </div>
+
+    <div class="d-flex align-items-center flex-wrap" style="min-height: 10rem;">
+      <div class="col p-3 text-center">
+        <i class="fa fa-battery-full"></i>
+        <i class="fa fa-battery-full text-primary" style="font-size: 1.5rem;"></i>
+        <i class="fa fa-battery-full bg-dark text-white" style="font-size: 2rem;"></i>
+        <p class="w-100 pt-3" style="white-space: nowrap;"><code>fa fa-battery-full</code></p>
       </div>
 
-    {% endblock column_1 %}
-  {% endembed %}
-</div>
+      <div class="col p-3 text-center">
+        <i class="fa fa-moon-o"></i>
+        <i class="fa fa-moon-o text-primary" style="font-size: 1.5rem;"></i>
+        <i class="fa fa-moon-o bg-dark text-white" style="font-size: 2rem;"></i>
+        <p class="w-100 pt-3" style="white-space: nowrap;"><code>fa fa-moon-o</code></p>
+      </div>
+
+      <div class="col p-3 text-center">
+        <i class="fa fa-medkit"></i>
+        <i class="fa fa-medkit text-primary" style="font-size: 1.5rem;"></i>
+        <i class="fa fa-medkit bg-dark text-white" style="font-size: 2rem;"></i>
+        <p class="w-100 pt-3" style="white-space: nowrap;"><code>fa fa-medkit</code></p>
+      </div>
+
+      <div class="col p-3 text-center" style="max-width: 240px;">
+        <i class="fontawesome-example"></i>
+        <i class="fontawesome-example text-primary" style="font-size: 1.5rem;"></i>
+        <i class="fontawesome-example bg-dark text-white" style="font-size: 2rem;"></i>
+        <p class="w-100 pt-3" style="white-space: nowrap; display: flex; flex-direction: column;"><code>@include fa-icon();</code><code>content: $fa-var-train;</code></p>
+      </div>
+
+      <div class="col p-3 text-center" style="max-width: 240px;">
+        <i class="fontawesome-example2"></i>
+        <i class="fontawesome-example2 text-primary" style="font-size: 1.5rem;"></i>
+        <i class="fontawesome-example2 bg-dark text-white" style="font-size: 2rem;"></i>
+        <p class="w-100 pt-3" style="white-space: nowrap; display: flex; flex-direction: column;"><code>@include fa-icon();</code><code>content: $fa-var-compass;</code></p>
+      </div>
+
+      <div class="col p-3 text-center" style="max-width: 240px;">
+        <i class="fontawesome-example3"></i>
+        <i class="fontawesome-example3 text-primary" style="font-size: 1.5rem;"></i>
+        <i class="fontawesome-example3 bg-dark text-white" style="font-size: 2rem;"></i>
+        <p class="w-100 pt-3" style="white-space: nowrap; display: flex; flex-direction: column;"><code>@include fa-icon();</code><code>content: $fa-var-apple;</code></p>
+      </div>
+    </div>
+
+  {% endblock column_1 %}

--- a/source/_patterns/01-atoms/image/demo/image-img.twig
+++ b/source/_patterns/01-atoms/image/demo/image-img.twig
@@ -3,7 +3,9 @@ All paths reference distributed OUTPUT, not local. Static assets are only
 referencable post-build.
 #}
 
-{% embed '@atoms/_grid-2-up.twig' with { container: true } %}
+{% extends '@atoms/_grid-2-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
     <h2>SVG (in pattern)</h2>
     {% include "@atoms/_image.twig" with {
@@ -21,4 +23,3 @@ referencable post-build.
       }
     } %}
   {% endblock column_2 %}
-{% endembed %}

--- a/source/_patterns/01-atoms/image/demo/image-inline.twig
+++ b/source/_patterns/01-atoms/image/demo/image-inline.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
 
     <h1>Inline SVG</h1>
@@ -16,4 +18,3 @@
     } %}
 
   {% endblock column_1 %}
-{% endembed %}

--- a/source/_patterns/01-atoms/image/demo/image-styles.twig
+++ b/source/_patterns/01-atoms/image/demo/image-styles.twig
@@ -1,17 +1,15 @@
-<div class="container">
-  {% embed '@atoms/grid/_grid-1-up.twig' %}
-    {% block column_1 %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
 
-      <h1>Image styles</h1>
+  {% block column_1 %}
 
-      {% for imageStyleName, imageStyleSetting in imageStyles %}
-        <div class="mb-3">
-          {% include "@atoms/_image.twig" with {
-            imageStyleName: imageStyleName
-          } %}
-        </div>
-      {% endfor %}
+    <h1>Image styles</h1>
+    {% for imageStyleName, imageStyleSetting in imageStyles %}
+      <div class="mb-3">
+        {% include "@atoms/_image.twig" with {
+          imageStyleName: imageStyleName
+        } %}
+      </div>
+    {% endfor %}
 
-    {% endblock %}
-  {% endembed %}
-</div>
+  {% endblock %}

--- a/source/_patterns/01-atoms/list-group/_list-group.twig
+++ b/source/_patterns/01-atoms/list-group/_list-group.twig
@@ -1,5 +1,6 @@
 {#
   List-group:
+
   parent_element: String: ul|ol|div The html element that will contain the list.
   list_id: String: a unique id for the list.
   items: Object: The items you wish you put into a list.
@@ -8,6 +9,8 @@
   item_text: String: The text of the list item.
   item_badge: Array: See the documentation for badges in source/_patterns/01-atoms/badge/_badge.twig.
   list_flush: Boolean: True|False Only use this variable if the list is on a card. this will make it align properly.
+
+  see https://getbootstrap.com/docs/4.0/components/list-group/
 #}
 
 {% set parent_element = parent_element | default('ul') %}

--- a/source/_patterns/01-atoms/list-group/_list-group.twig
+++ b/source/_patterns/01-atoms/list-group/_list-group.twig
@@ -20,7 +20,6 @@
   {% set list_id = 'id="' ~ list_id ~ '"' %}
 {% endif %}
 
-
 <{{ parent_element }} class="list-group {{ list_flush }}" {{ list_id }}>
   {% for item in items %}
 

--- a/source/_patterns/01-atoms/list-group/demo/list-groups.twig
+++ b/source/_patterns/01-atoms/list-group/demo/list-groups.twig
@@ -4,204 +4,203 @@
   {% set colors = colors|merge([name]) %}
 {% endfor %}
 
-<div class="container">
-  {% embed '@atoms/grid/_grid-1-up.twig' %}
-    {% block column_1 %}
-      <div class="mb-3">
-        <h1>List Group</h1>
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_text: list_group_helper,
-          card_background: 'secondary',
-          text_color: 'light',
-        } %}
-      </div>
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
 
-      {# Basic examples #}
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Basic Examples',
-          card_text: list_group_helper_basic,
-        } %}
-      </div>
-      <div class="row mb-3">
-        <div class="col-sm-6">
-          {% include '@atoms/list-group/_list-group.twig' with list_group_text %}
-        </div>
-        <div class="col-sm-6">
-          {# This block of code is going to appear multiple times. It exists because the _list-group.twig
-          template ultimately needs an object to iterate through to generate the individual items. These code
-          blocks exist to pull data from multiple disperate places (the all_colors array, list-groups.yml,
-          etc.) and combine them into a single object that the template can then process. #}
-          {% set color_items = [] %}
-          {# Iterate over colors, since this is actually what we're demo'ing #}
-          {% for color in colors %}
-            {# Inline object merged into random text object #}
-            {% set temp_item = { item_color: color } | merge(random(list_group_text.items)) %}
-            {# Build up the color_items array #}
-            {% set color_items = color_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: color_items
-          } %}
-        </div>
-      </div>
+  {% block column_1 %}
+    <div class="mb-3">
+      <h1>List Group</h1>
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_text: list_group_helper,
+        card_background: 'secondary',
+        text_color: 'light',
+      } %}
+    </div>
 
-      {# Active and Disabled Items #}
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Active and Disabled Items',
-          card_text: list_group_helper_active,
+    {# Basic examples #}
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Basic Examples',
+        card_text: list_group_helper_basic,
+      } %}
+    </div>
+    <div class="row mb-3">
+      <div class="col-sm-6">
+        {% include '@atoms/list-group/_list-group.twig' with list_group_text %}
+      </div>
+      <div class="col-sm-6">
+        {# This block of code is going to appear multiple times. It exists because the _list-group.twig
+        template ultimately needs an object to iterate through to generate the individual items. These code
+        blocks exist to pull data from multiple disperate places (the all_colors array, list-groups.yml,
+        etc.) and combine them into a single object that the template can then process. #}
+        {% set color_items = [] %}
+        {# Iterate over colors, since this is actually what we're demo'ing #}
+        {% for color in colors %}
+          {# Inline object merged into random text object #}
+          {% set temp_item = { item_color: color } | merge(random(list_group_text.items)) %}
+          {# Build up the color_items array #}
+          {% set color_items = color_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: color_items
         } %}
       </div>
-      <div class="row mb-3">
-        <div class="col-sm">
-          <h2>Active Items</h2>
-          {% set active_items = [] %}
-          {% for item in list_group_active %}
-            {% set temp_item = item | merge(random(list_group_text.items)) %}
-            {% set active_items = active_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: active_items
-          } %}
-        </div>
-        <div class="col-sm">
-          <h2>Disabled Items</h2>
-          {% set disabled_items = [] %}
-          {% for item in list_group_disabled %}
-            {% set temp_item = item | merge(random(list_group_text.items)) %}
-            {% set disabled_items = disabled_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: disabled_items
-          } %}
-        </div>
-        <div class="col-sm">
-          <h2>Action</h2>
-          {% set action_items = [] %}
-          {% for item in list_group_text.items %}
-            {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_classes: ['list-group-item-action']}) %}
-            {% set action_items = action_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: action_items
-          } %}
-        </div>
-      </div>
+    </div>
 
-      {# Other Elements #}
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Other elements',
-          card_text: list_group_helper_elements,
+    {# Active and Disabled Items #}
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Active and Disabled Items',
+        card_text: list_group_helper_active,
+      } %}
+    </div>
+    <div class="row mb-3">
+      <div class="col-sm">
+        <h2>Active Items</h2>
+        {% set active_items = [] %}
+        {% for item in list_group_active %}
+          {% set temp_item = item | merge(random(list_group_text.items)) %}
+          {% set active_items = active_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: active_items
         } %}
       </div>
-      <div class="row mb-3">
-        <div class="col-sm">
-          <h2>Link List</h2>
-          {% set link_items = [] %}
-          {% for item in list_group_text.items %}
-            {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_element: 'a'}) %}
-            {% set link_items = link_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: link_items,
-          } %}
-        </div>
-        <div class="col-sm">
-          <h2>Button</h2>
-          {% set button_items = [] %}
-          {% for item in list_group_text.items %}
-            {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_element: 'button'}) %}
-            {% set button_items = button_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: button_items,
-          } %}
-        </div>
+      <div class="col-sm">
+        <h2>Disabled Items</h2>
+        {% set disabled_items = [] %}
+        {% for item in list_group_disabled %}
+          {% set temp_item = item | merge(random(list_group_text.items)) %}
+          {% set disabled_items = disabled_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: disabled_items
+        } %}
       </div>
+      <div class="col-sm">
+        <h2>Action</h2>
+        {% set action_items = [] %}
+        {% for item in list_group_text.items %}
+          {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_classes: ['list-group-item-action']}) %}
+          {% set action_items = action_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: action_items
+        } %}
+      </div>
+    </div>
 
-      {# Adding Elements #}
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Adding Elements',
-          card_text: list_group_helper_adding,
+    {# Other Elements #}
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Other elements',
+        card_text: list_group_helper_elements,
+      } %}
+    </div>
+    <div class="row mb-3">
+      <div class="col-sm">
+        <h2>Link List</h2>
+        {% set link_items = [] %}
+        {% for item in list_group_text.items %}
+          {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_element: 'a'}) %}
+          {% set link_items = link_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: link_items,
         } %}
       </div>
-      <div class="row mb-3">
-        <div class="col-sm">
-          <h2>Badges</h2>
-          {% set badge_data = {
-            badge_text: 'badge',
-            badge_pill: 'true',
-          } %}
-          {% set badge_classes = [
-            'list-group-item',
-            'd-flex',
-            'justify-content-between',
-            'align-items-center',
-          ] %}
-          {% set badge_items = [] %}
-          {% for item in list_group_text.items %}
-            {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_badge: badge_data}) | merge({item_classes: badge_classes}) %}
-            {% set badge_items = badge_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: badge_items
-          } %}
-        </div>
-        <div class="col-sm">
-          <h2>Custom HTML</h2>
-          {% set custom_items = [] %}
-          {% set custom_classes = [
-            'list-group-item',
-            'list-group-item-action',
-            'flex-column',
-            'align-items-start',
-          ] %}
-          {% for item in list_group_custom_text.items %}
-            {% set temp_item = item | merge({item_classes: custom_classes}) %}
-            {% set custom_items = custom_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            items: custom_items,
-          } %}
-        </div>
+      <div class="col-sm">
+        <h2>Button</h2>
+        {% set button_items = [] %}
+        {% for item in list_group_text.items %}
+          {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_element: 'button'}) %}
+          {% set button_items = button_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: button_items,
+        } %}
       </div>
+    </div>
 
-      {#Toggleable Items#}
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Toggleable Items',
-          card_text: list_group_helper_toggleable,
-          button: {
-            button_link: 'https://getbootstrap.com/docs/4.0/components/list-group/#via-javascript',
-          }
+    {# Adding Elements #}
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Adding Elements',
+        card_text: list_group_helper_adding,
+      } %}
+    </div>
+    <div class="row mb-3">
+      <div class="col-sm">
+        <h2>Badges</h2>
+        {% set badge_data = {
+          badge_text: 'badge',
+          badge_pill: 'true',
+        } %}
+        {% set badge_classes = [
+          'list-group-item',
+          'd-flex',
+          'justify-content-between',
+          'align-items-center',
+        ] %}
+        {% set badge_items = [] %}
+        {% for item in list_group_text.items %}
+          {% set temp_item = item | merge({item_color: random(colors)}) | merge({item_badge: badge_data}) | merge({item_classes: badge_classes}) %}
+          {% set badge_items = badge_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: badge_items
         } %}
       </div>
-      <div class="row mb-3">
-        <div class="col-sm">
-          <h2>Toggleable</h2>
-          {% set toggle_items = [] %}
-          {% for item in list_group_toggleable.items %}
-            {% set temp_item = item | merge({item_element: 'a'}) %}
-            {% set toggle_items = toggle_items|merge([temp_item]) %}
-          {% endfor %}
-          {% include '@atoms/list-group/_list-group.twig' with {
-            parent_element: 'div',
-            list_id: 'mylist',
-            items: toggle_items,
-          } %}
-        </div>
-        <div class="col-sm">
-          <div class="tab-content" id="nav-tabContent">
-            <div class="tab-pane fade show active" id="list-home" role="tabpanel" aria-labelledby="list-home-list">This is home content!</div>
-            <div class="tab-pane fade" id="list-profile" role="tabpanel" aria-labelledby="list-profile-list">This is profile content!</div>
-            <div class="tab-pane fade" id="list-messages" role="tabpanel" aria-labelledby="list-messages-list">This is messages content!</div>
-            <div class="tab-pane fade" id="list-settings" role="tabpanel" aria-labelledby="list-settings-list">This is settings content!</div>
-          </div>
+      <div class="col-sm">
+        <h2>Custom HTML</h2>
+        {% set custom_items = [] %}
+        {% set custom_classes = [
+          'list-group-item',
+          'list-group-item-action',
+          'flex-column',
+          'align-items-start',
+        ] %}
+        {% for item in list_group_custom_text.items %}
+          {% set temp_item = item | merge({item_classes: custom_classes}) %}
+          {% set custom_items = custom_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          items: custom_items,
+        } %}
+      </div>
+    </div>
+
+    {#Toggleable Items#}
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Toggleable Items',
+        card_text: list_group_helper_toggleable,
+        button: {
+          button_link: 'https://getbootstrap.com/docs/4.0/components/list-group/#via-javascript',
+        }
+      } %}
+    </div>
+    <div class="row mb-3">
+      <div class="col-sm">
+        <h2>Toggleable</h2>
+        {% set toggle_items = [] %}
+        {% for item in list_group_toggleable.items %}
+          {% set temp_item = item | merge({item_element: 'a'}) %}
+          {% set toggle_items = toggle_items|merge([temp_item]) %}
+        {% endfor %}
+        {% include '@atoms/list-group/_list-group.twig' with {
+          parent_element: 'div',
+          list_id: 'mylist',
+          items: toggle_items,
+        } %}
+      </div>
+      <div class="col-sm">
+        <div class="tab-content" id="nav-tabContent">
+          <div class="tab-pane fade show active" id="list-home" role="tabpanel" aria-labelledby="list-home-list">This is home content!</div>
+          <div class="tab-pane fade" id="list-profile" role="tabpanel" aria-labelledby="list-profile-list">This is profile content!</div>
+          <div class="tab-pane fade" id="list-messages" role="tabpanel" aria-labelledby="list-messages-list">This is messages content!</div>
+          <div class="tab-pane fade" id="list-settings" role="tabpanel" aria-labelledby="list-settings-list">This is settings content!</div>
         </div>
       </div>
-    {% endblock column_1 %}
-  {% endembed %}
-</div>
+    </div>
+  {% endblock column_1 %}

--- a/source/_patterns/01-atoms/list-group/demo/list-groups.twig
+++ b/source/_patterns/01-atoms/list-group/demo/list-groups.twig
@@ -148,7 +148,7 @@
           {% set badge_items = badge_items|merge([temp_item]) %}
         {% endfor %}
         {% include '@atoms/list-group/_list-group.twig' with {
-          items: badge_items
+          items: badge_items,
         } %}
       </div>
       <div class="col-sm">
@@ -177,7 +177,7 @@
         card_text: list_group_helper_toggleable,
         button: {
           button_link: 'https://getbootstrap.com/docs/4.0/components/list-group/#via-javascript',
-        }
+        },
       } %}
     </div>
     <div class="row mb-3">

--- a/source/_patterns/02-molecules/card/_card.twig
+++ b/source/_patterns/02-molecules/card/_card.twig
@@ -20,10 +20,11 @@
   card_list: Number: The number of items in the list.
   list_item: Loop variable: Do not set.
   card_footer: String: The text on the footer.
+
   see https://getbootstrap.com/docs/4.0/components/card/ for more details
 #}
 
-{% set classes = classes|default([])|merge([
+{% set card_classes = [
   'card',
   card_width ? 'w-' ~ card_width,
   card_cols ? card_cols : '',
@@ -31,9 +32,10 @@
   text_color ? 'text-' ~ text_color,
   card_background ? 'bg-' ~ card_background,
   card_border ? 'border-' ~ card_border,
-]) | sort | join(' ') | trim %}
+  card_other_classes,
+] | sort | join(' ') | trim %}
 
-<div class="{{ classes }}">
+<div class="{{ card_classes }}">
   {% block card_header %}
     {% if card_header %}
       <div class="card-header">

--- a/source/_patterns/02-molecules/card/demo/cards.twig
+++ b/source/_patterns/02-molecules/card/demo/cards.twig
@@ -16,7 +16,7 @@
         card_text: helper_card_text,
         button: {
           button_link: 'https://getbootstrap.com/docs/4.0/layout/grid/#how-it-works',
-        }
+        },
       } %}
     </div>
     <div class="row">
@@ -56,7 +56,7 @@
         card_text: helper_card_width,
         button: {
           button_link: 'https://getbootstrap.com/docs/4.0/layout/grid/#how-it-works',
-        }
+        },
       } %}
     </div>
     <div class="row">
@@ -73,7 +73,7 @@
         card_text: helper_card_image,
         button: {
           button_link: 'https://getbootstrap.com/docs/4.0/components/card/#card-decks',
-        }
+        },
       } %}
     </div>
     <div class="card-deck mb-3">
@@ -88,7 +88,7 @@
         card_text: helper_card_structure,
         button: {
           button_link: 'https://getbootstrap.com/docs/4.0/components/card/#header-and-footer',
-        }
+        },
       } %}
     </div>
     <div class="card-group mb-3">
@@ -103,7 +103,7 @@
         card_text: helper_card_colors,
         button: {
           button_link: 'https://getbootstrap.com/docs/4.0/components/card/#card-columns',
-        }
+        },
       } %}
     </div>
     <div class="card-columns mb-3">

--- a/source/_patterns/02-molecules/card/demo/cards.twig
+++ b/source/_patterns/02-molecules/card/demo/cards.twig
@@ -1,135 +1,134 @@
-<div class="container">
-  {% embed '@atoms/grid/_grid-1-up.twig' %}
-    {% block column_1 %}
-      <h1>Cards</h1>
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_text: helper_card_main,
-          card_background: 'secondary',
-          text_color: 'light',
-        } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
+  {% block column_1 %}
+    <h1>Cards</h1>
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_text: helper_card_main,
+        card_background: 'secondary',
+        text_color: 'light',
+      } %}
+    </div>
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Text',
+        card_text: helper_card_text,
+        button: {
+          button_link: 'https://getbootstrap.com/docs/4.0/layout/grid/#how-it-works',
+        }
+      } %}
+    </div>
+    <div class="row">
+      <div class="col-sm mb-3">
+        {% include '@molecules/card/_card.twig' with text_card_1 %}
       </div>
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Text',
-          card_text: helper_card_text,
-          button: {
-            button_link: 'https://getbootstrap.com/docs/4.0/layout/grid/#how-it-works',
-          }
-        } %}
+      <div class="col-sm mb-3">
+        {% include '@molecules/card/_card.twig' with text_card_2 %}
       </div>
-      <div class="row">
-        <div class="col-sm mb-3">
+      <div class="col-sm mb-3">
+        {% include '@molecules/card/_card.twig' with text_card_3 %}
+      </div>
+    </div>
+
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_text: helper_card_text_2,
+      } %}
+    </div>
+    <div class="mb-3">
+      {% embed '@atoms/grid/_grid-3-up.twig' %}
+        {% block column_1 %}
           {% include '@molecules/card/_card.twig' with text_card_1 %}
-        </div>
-        <div class="col-sm mb-3">
+        {% endblock column_1 %}
+        {% block column_2 %}
           {% include '@molecules/card/_card.twig' with text_card_2 %}
-        </div>
-        <div class="col-sm mb-3">
+        {% endblock column_2 %}
+        {% block column_3 %}
           {% include '@molecules/card/_card.twig' with text_card_3 %}
-        </div>
-      </div>
+        {% endblock column_3 %}
+      {% endembed %}
+    </div>
 
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_text: helper_card_text_2,
-        } %}
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Width',
+        card_text: helper_card_width,
+        button: {
+          button_link: 'https://getbootstrap.com/docs/4.0/layout/grid/#how-it-works',
+        }
+      } %}
+    </div>
+    <div class="row">
+      <div class="col-sm-12 mb-3">
+        {% include '@molecules/card/_card.twig' with card_width_1 %}
+        {% include '@molecules/card/_card.twig' with card_width_2 %}
+        {% include '@molecules/card/_card.twig' with card_width_3 %}
       </div>
-      <div class="mb-3">
-        {% embed '@atoms/grid/_grid-3-up.twig' %}
-          {% block column_1 %}
-            {% include '@molecules/card/_card.twig' with text_card_1 %}
-          {% endblock column_1 %}
-          {% block column_2 %}
-            {% include '@molecules/card/_card.twig' with text_card_2 %}
-          {% endblock column_2 %}
-          {% block column_3 %}
-            {% include '@molecules/card/_card.twig' with text_card_3 %}
-          {% endblock column_3 %}
-        {% endembed %}
-      </div>
+    </div>
 
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Width',
-          card_text: helper_card_width,
-          button: {
-            button_link: 'https://getbootstrap.com/docs/4.0/layout/grid/#how-it-works',
-          }
-        } %}
-      </div>
-      <div class="row">
-        <div class="col-sm-12 mb-3">
-          {% include '@molecules/card/_card.twig' with card_width_1 %}
-          {% include '@molecules/card/_card.twig' with card_width_2 %}
-          {% include '@molecules/card/_card.twig' with card_width_3 %}
-        </div>
-      </div>
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Image',
+        card_text: helper_card_image,
+        button: {
+          button_link: 'https://getbootstrap.com/docs/4.0/components/card/#card-decks',
+        }
+      } %}
+    </div>
+    <div class="card-deck mb-3">
+      {% include '@molecules/card/_card.twig' with top_image %}
+      {% include '@molecules/card/_card.twig' with bottom_image %}
+      {% include '@molecules/card/_card.twig' with overlay_image %}
+    </div>
 
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Image',
-          card_text: helper_card_image,
-          button: {
-            button_link: 'https://getbootstrap.com/docs/4.0/components/card/#card-decks',
-          }
-        } %}
-      </div>
-      <div class="card-deck mb-3">
-        {% include '@molecules/card/_card.twig' with top_image %}
-        {% include '@molecules/card/_card.twig' with bottom_image %}
-        {% include '@molecules/card/_card.twig' with overlay_image %}
-      </div>
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Structure',
+        card_text: helper_card_structure,
+        button: {
+          button_link: 'https://getbootstrap.com/docs/4.0/components/card/#header-and-footer',
+        }
+      } %}
+    </div>
+    <div class="card-group mb-3">
+      {% include '@molecules/card/_card.twig' with header_card %}
+      {% include '@molecules/card/_card.twig' with footer_card %}
+      {% include '@molecules/card/_card.twig' with list_card %}
+    </div>
 
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Structure',
-          card_text: helper_card_structure,
-          button: {
-            button_link: 'https://getbootstrap.com/docs/4.0/components/card/#header-and-footer',
-          }
-        } %}
-      </div>
-      <div class="card-group mb-3">
-        {% include '@molecules/card/_card.twig' with header_card %}
-        {% include '@molecules/card/_card.twig' with footer_card %}
-        {% include '@molecules/card/_card.twig' with list_card %}
-      </div>
-
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Background and Border',
-          card_text: helper_card_colors,
-          button: {
-            button_link: 'https://getbootstrap.com/docs/4.0/components/card/#card-columns',
-          }
-        } %}
-      </div>
-      <div class="card-columns mb-3">
-        {% include '@molecules/card/_card.twig' with card_background_1 %}
-        {% include '@molecules/card/_card.twig' with card_background_2 %}
-        {% include '@molecules/card/_card.twig' with card_background_3 %}
-        {% include '@molecules/card/_card.twig' with card_background_4 %}
-        {% include '@molecules/card/_card.twig' with card_border_1 %}
-        {% include '@molecules/card/_card.twig' with card_border_2 %}
-        {% include '@molecules/card/_card.twig' with card_border_3 %}
-        {% include '@molecules/card/_card.twig' with card_border_4 %}
-      </div>
-      <div class="mb-3">
-        {% include '@molecules/card/_card-helper.twig' with {
-          card_title: 'Variation',
-          card_text: helper_card_blocks,
-        } %}
-      </div>
-      <div class="mb3">
-        {% embed '@molecules/card/_card.twig' %}
-          {% block card_body %}
-            <h2 class="text-left">First Title</h2>
-            <h2 class="text-right">Second Title</h2>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sit amet facilisis erat. Suspendisse ultrices sed massa a faucibus. </p>
-          {% endblock %}
-        {% endembed %}
-      </div>
-    {% endblock column_1 %}
-  {% endembed %}
-</div>
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Background and Border',
+        card_text: helper_card_colors,
+        button: {
+          button_link: 'https://getbootstrap.com/docs/4.0/components/card/#card-columns',
+        }
+      } %}
+    </div>
+    <div class="card-columns mb-3">
+      {% include '@molecules/card/_card.twig' with card_background_1 %}
+      {% include '@molecules/card/_card.twig' with card_background_2 %}
+      {% include '@molecules/card/_card.twig' with card_background_3 %}
+      {% include '@molecules/card/_card.twig' with card_background_4 %}
+      {% include '@molecules/card/_card.twig' with card_border_1 %}
+      {% include '@molecules/card/_card.twig' with card_border_2 %}
+      {% include '@molecules/card/_card.twig' with card_border_3 %}
+      {% include '@molecules/card/_card.twig' with card_border_4 %}
+    </div>
+    <div class="mb-3">
+      {% include '@molecules/card/_card-helper.twig' with {
+        card_title: 'Variation',
+        card_text: helper_card_blocks,
+      } %}
+    </div>
+    <div class="mb3">
+      {% embed '@molecules/card/_card.twig' %}
+        {% block card_body %}
+          <h2 class="text-left">First Title</h2>
+          <h2 class="text-right">Second Title</h2>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sit amet facilisis erat. Suspendisse ultrices sed massa a faucibus. </p>
+        {% endblock %}
+      {% endembed %}
+    </div>
+  {% endblock column_1 %}

--- a/source/_patterns/02-molecules/card/demo/cards.yml
+++ b/source/_patterns/02-molecules/card/demo/cards.yml
@@ -27,7 +27,7 @@ text_card_2:
   card_title: Card Title
   card_text: Some quick example text to build on the card title and make up the bulk of the card's content.
   card_subtitle: Card subtitle
-  card_link: 'https://github.com/phase2/pattern-lab-starter'
+  card_link: 'https://github.com/phase2/particle'
   card_link_text: 'Card link'
 
 text_card_3:

--- a/source/_patterns/02-molecules/carousel/_carousel.twig
+++ b/source/_patterns/02-molecules/carousel/_carousel.twig
@@ -10,7 +10,7 @@
   see https://getbootstrap.com/docs/4.0/components/carousel/ for more details
 #}
 
-{% set carousel_id = random(9999) %}
+{% set carousel_id = random() %}
 
 <div id="{{ 'carousel-' ~ carousel_id }}" class="carousel slide" data-ride="carousel">
   {% block indicators %}

--- a/source/_patterns/02-molecules/carousel/_carousel.twig
+++ b/source/_patterns/02-molecules/carousel/_carousel.twig
@@ -10,6 +10,8 @@
   see https://getbootstrap.com/docs/4.0/components/carousel/ for more details
 #}
 
+{% set carousel_id = random(9999) %}
+
 <div id="{{ 'carousel-' ~ carousel_id }}" class="carousel slide" data-ride="carousel">
   {% block indicators %}
     {% if carousel_indicators %}

--- a/source/_patterns/02-molecules/carousel/_carousel.twig
+++ b/source/_patterns/02-molecules/carousel/_carousel.twig
@@ -25,7 +25,7 @@
       <div class="carousel-item {{ (image.active) ? 'active' }}">
         {% include '@atoms/image/_image.twig' with {
           imageStyleName: 'carousel',
-          class: 'img img-responsive'
+          class: 'img img-responsive',
         } %}
         {% if carousel_caption %}
           <div class="carousel-caption d-none d-md-block">

--- a/source/_patterns/02-molecules/carousel/demo/carousels.twig
+++ b/source/_patterns/02-molecules/carousel/demo/carousels.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
     <h1>Carousel</h1>
 
@@ -27,4 +29,3 @@
     {% include '@molecules/carousel/_carousel.twig' with carousel_4 %}
 
   {% endblock %}
-{% endembed %}

--- a/source/_patterns/02-molecules/carousel/demo/carousels.yml
+++ b/source/_patterns/02-molecules/carousel/demo/carousels.yml
@@ -1,5 +1,4 @@
 carousel_1:
-  carousel_id: 1
   carousel_images:
     -
       active: TRUE
@@ -9,7 +8,6 @@ carousel_1:
       active: FALSE
 
 carousel_2:
-  carousel_id: 2
   carousel_controls: TRUE
   carousel_images:
     -
@@ -20,7 +18,6 @@ carousel_2:
       active: FALSE
 
 carousel_3:
-  carousel_id: 3
   carousel_controls: TRUE
   carousel_indicators:
     - active: TRUE
@@ -35,7 +32,6 @@ carousel_3:
       active: FALSE
 
 carousel_4:
-  carousel_id: 4
   carousel_controls: TRUE
   carousel_caption: TRUE
   carousel_indicators:

--- a/source/_patterns/02-molecules/jumbotron/_jumbotron.twig
+++ b/source/_patterns/02-molecules/jumbotron/_jumbotron.twig
@@ -16,12 +16,13 @@
   see https://getbootstrap.com/docs/4.0/components/jumbotron/ for more details
 #}
 
-{% set classes = [
+{% set jumbotron_classes = [
   'jumbotron',
   jumbotron_fluid ? 'jumbotron-fluid',
-] | join(' ') %}
+  jumbotron_other_classes,
+] | sort | join(' ') | trim %}
 
-<div class="{{ classes }}">
+<div class="{{ jumbotron_classes }}">
   {% if jumbotron_fluid %}
     <div class="container">
   {% endif %}

--- a/source/_patterns/02-molecules/jumbotron/demo/jumbotrons.twig
+++ b/source/_patterns/02-molecules/jumbotron/demo/jumbotrons.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
 
     {% block jumbo_basic %}
@@ -15,4 +17,3 @@
     </p>
 
   {% endblock %}
-{% endembed %}

--- a/source/_patterns/02-molecules/jumbotron/demo/jumbotrons.yml
+++ b/source/_patterns/02-molecules/jumbotron/demo/jumbotrons.yml
@@ -5,7 +5,7 @@ basic_jumbotron:
   button_text: Learn more
   button_color: primary
   button_size: lg
-  button_link: 'https://github.com/phase2/pattern-lab-starter'
+  button_link: 'https://github.com/phase2/particle'
 
 fluid_jumbotron:
   jumbotron_title: Fluid Jumbotron

--- a/source/_patterns/02-molecules/nav/_nav-item.twig
+++ b/source/_patterns/02-molecules/nav/_nav-item.twig
@@ -1,5 +1,6 @@
 {#
   Nav Item!
+
   nav_item_link: String: The URL the nav item will lead to.
   nav_item_element: String: The nav-item's html element.
   nav_item_js: Boolean: True|False: Choose whether to use bootstrap's built-in nav javascript.
@@ -20,7 +21,7 @@
     'data-toggle="tab"',
     'role="tab"',
     'aria-controls="' ~ nav_item_text ~ '"',
-  ] | join(' ')%}
+  ] | sort | join(' ') | trim %}
   {#test hfref ^#}
 {% endif %}
 

--- a/source/_patterns/02-molecules/nav/_nav.twig
+++ b/source/_patterns/02-molecules/nav/_nav.twig
@@ -1,5 +1,6 @@
 {#
   Nav!
+
   nav_element: String: Choose the html element of the nav.
   nav_id: String: Choose the html id of the nav.
   nav_role: String: Choose the html role of the nav.
@@ -15,21 +16,22 @@
   item.nav_item_dropdown: Boolean: True | False: Set the selected nav.item as a dropdown menu.
 #}
 
-  {% set nav_element = nav_element | default('nav') %}
-  {% set nav_id = nav_id ? 'id="' ~ nav_id ~ '"' %}
-  {% set nav_role = nav_role ? 'role="' ~ nav_role ~ '"' %}
+{% set nav_element = nav_element | default('nav') %}
+{% set nav_id = nav_id ? 'id="' ~ nav_id ~ '"' %}
+{% set nav_role = nav_role ? 'role="' ~ nav_role ~ '"' %}
 
-  {% set classes = [
-    'nav',
-    nav_alignment ? 'justify-content-' ~ nav_alignment,
-    nav_vertical ? 'flex-column',
-    nav_tabs ? 'nav-tabs',
-    nav_pill ? 'nav-pills',
-    nav_fill ? 'nav-fill',
-    nav_justify ? 'nav-justified',
-  ] | join(' ') ~ nav_other_classes %}
+{% set nav_classes = [
+  'nav',
+  nav_alignment ? 'justify-content-' ~ nav_alignment,
+  nav_vertical ? 'flex-column',
+  nav_tabs ? 'nav-tabs',
+  nav_pill ? 'nav-pills',
+  nav_fill ? 'nav-fill',
+  nav_justify ? 'nav-justified',
+  nav_other_classes
+] | sort | join(' ') | trim %}
 
-<{{ nav_element }} class="{{ classes }}" {{ nav_id }} {{ nav_role }}>
+<{{ nav_element }} class="{{ nav_classes }}" {{ nav_id }} {{ nav_role }}>
   {% for item in nav_items %}
     {% if item.nav_item_dropdown %}
       {% include '@atoms/dropdown/_dropdown.twig' with item %}

--- a/source/_patterns/02-molecules/nav/demo/navs.twig
+++ b/source/_patterns/02-molecules/nav/demo/navs.twig
@@ -9,7 +9,7 @@
       text_color: 'light',
       button: {
         button_link: 'http://getbootstrap.com/docs/4.0/components/navs/',
-      }
+      },
     } %}
 
     <div class="mb-3">
@@ -32,37 +32,37 @@
     <div class=" mb-3">
       <h1>Vertical Alignment</h1>
       {% include '@molecules/nav/_nav.twig' with {
-        nav_vertical: 'true',
+        nav_vertical: true,
       } %}
     </div>
 
     <div class=" mb-3">
       <h1>Tabs</h1>
       {% include '@molecules/nav/_nav.twig' with {
-        nav_tabs: 'true',
+        nav_tabs: true,
       } %}
     </div>
 
     <div class=" mb-3">
       <h1>Pills</h1>
       {% include '@molecules/nav/_nav.twig' with {
-        nav_pill: 'true',
+        nav_pill: true,
       } %}
     </div>
 
     <div class=" mb-3">
       <h1>Fill</h1>
       {% include '@molecules/nav/_nav.twig' with {
-        nav_pill: 'true',
-        nav_fill: 'true',
+        nav_pill: true,
+        nav_fill: true,
       } %}
     </div>
 
     <div class=" mb-3">
       <h1>Justify</h1>
       {% include '@molecules/nav/_nav.twig' with {
-        nav_pill: 'true',
-        nav_justify: 'true',
+        nav_pill: true,
+        nav_justify: true,
       } %}
     </div>
 
@@ -74,7 +74,7 @@
         {% set responsive_items = responsive_items|merge([temp_item]) %}
       {% endfor %}
       {% include '@molecules/nav/_nav.twig' with {
-        nav_pill: 'true',
+        nav_pill: true,
         nav_other_classes: 'flex-column flex-sm-row',
         nav_items: responsive_items,
       } %}

--- a/source/_patterns/02-molecules/nav/demo/navs.twig
+++ b/source/_patterns/02-molecules/nav/demo/navs.twig
@@ -1,111 +1,112 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
-    {% block column_1 %}
-      <h1>Navs</h1>
-      {% include '@molecules/card/_card-helper.twig' with {
-        card_text: navs_helper,
-        card_background: 'secondary',
-        text_color: 'light',
-        button: {
-          button_link: 'http://getbootstrap.com/docs/4.0/components/navs/',
-        }
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
+  {% block column_1 %}
+    <h1>Navs</h1>
+    {% include '@molecules/card/_card-helper.twig' with {
+      card_text: navs_helper,
+      card_background: 'secondary',
+      text_color: 'light',
+      button: {
+        button_link: 'http://getbootstrap.com/docs/4.0/components/navs/',
+      }
+    } %}
+
+    <div class="mb-3">
+    <h1>Horizontal Alignment</h1>
+      <div class="nav--border">
+        {% include '@molecules/nav/_nav.twig' %}
+      </div>
+      <div class="nav--border">
+        {% include '@molecules/nav/_nav.twig' with {
+          nav_alignment: 'center',
+        } %}
+      </div>
+      <div class="nav--border">
+        {% include '@molecules/nav/_nav.twig' with {
+        nav_alignment: 'end',
+        } %}
+      </div>
+
+    </div>
+    <div class=" mb-3">
+      <h1>Vertical Alignment</h1>
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_vertical: 'true',
       } %}
+    </div>
 
-      <div class="mb-3">
-      <h1>Horizontal Alignment</h1>
-        <div class="nav--border">
-          {% include '@molecules/nav/_nav.twig' %}
-        </div>
-        <div class="nav--border">
-          {% include '@molecules/nav/_nav.twig' with {
-            nav_alignment: 'center',
-          } %}
-        </div>
-        <div class="nav--border">
-          {% include '@molecules/nav/_nav.twig' with {
-          nav_alignment: 'end',
-          } %}
-        </div>
+    <div class=" mb-3">
+      <h1>Tabs</h1>
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_tabs: 'true',
+      } %}
+    </div>
 
-      </div>
-      <div class=" mb-3">
-        <h1>Vertical Alignment</h1>
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_vertical: 'true',
-        } %}
-      </div>
+    <div class=" mb-3">
+      <h1>Pills</h1>
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_pill: 'true',
+      } %}
+    </div>
 
-      <div class=" mb-3">
-        <h1>Tabs</h1>
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_tabs: 'true',
-        } %}
-      </div>
+    <div class=" mb-3">
+      <h1>Fill</h1>
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_pill: 'true',
+        nav_fill: 'true',
+      } %}
+    </div>
 
-      <div class=" mb-3">
-        <h1>Pills</h1>
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_pill: 'true',
-        } %}
-      </div>
+    <div class=" mb-3">
+      <h1>Justify</h1>
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_pill: 'true',
+        nav_justify: 'true',
+      } %}
+    </div>
 
-      <div class=" mb-3">
-        <h1>Fill</h1>
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_pill: 'true',
-          nav_fill: 'true',
-        } %}
-      </div>
+    <div class=" mb-3">
+      <h1>Responsive nav</h1>
+      {% set responsive_items = [] %}
+      {% for item in nav_items_responsive %}
+        {% set temp_item = item | merge({nav_item_element: 'a'}) %}
+        {% set responsive_items = responsive_items|merge([temp_item]) %}
+      {% endfor %}
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_pill: 'true',
+        nav_other_classes: 'flex-column flex-sm-row',
+        nav_items: responsive_items,
+      } %}
+    </div>
 
-      <div class=" mb-3">
-        <h1>Justify</h1>
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_pill: 'true',
-          nav_justify: 'true',
-        } %}
-      </div>
+    <div class=" mb-3">
+      <h1>Dropdown</h1>
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_element: 'ul',
+        nav_tabs: 'true',
+        nav_items: nav_items_dropdown,
+      } %}
+    </div>
 
-      <div class=" mb-3">
-        <h1>Responsive nav</h1>
-        {% set responsive_items = [] %}
-        {% for item in nav_items_responsive %}
-          {% set temp_item = item | merge({nav_item_element: 'a'}) %}
-          {% set responsive_items = responsive_items|merge([temp_item]) %}
-        {% endfor %}
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_pill: 'true',
-          nav_other_classes: 'flex-column flex-sm-row',
-          nav_items: responsive_items,
-        } %}
+    <div class=" mb-3">
+      <h1>Javascript Tabs</h1>
+      {% set javascript_items = [] %}
+      {% for item in nav_items_javascript %}
+        {% set temp_item = item | merge({nav_item_js: 'true'}) %}
+        {% set javascript_items = javascript_items|merge([temp_item]) %}
+      {% endfor %}
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_element: 'ul',
+        nav_tabs: 'true',
+        nav_id: 'myTab',
+        nav_role: 'tablist',
+        nav_items: javascript_items,
+      } %}
+      <div class="tab-content" id="myTabContent">
+        <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">This is home content!</div>
+        <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">This is profile content!</div>
+        <div class="tab-pane fade" id="contact" role="tabpanel" aria-labelledby="contact-tab">This is contact content!</div>
       </div>
-
-      <div class=" mb-3">
-        <h1>Dropdown</h1>
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_element: 'ul',
-          nav_tabs: 'true',
-          nav_items: nav_items_dropdown,
-        } %}
-      </div>
-
-      <div class=" mb-3">
-        <h1>Javascript Tabs</h1>
-        {% set javascript_items = [] %}
-        {% for item in nav_items_javascript %}
-          {% set temp_item = item | merge({nav_item_js: 'true'}) %}
-          {% set javascript_items = javascript_items|merge([temp_item]) %}
-        {% endfor %}
-        {% include '@molecules/nav/_nav.twig' with {
-          nav_element: 'ul',
-          nav_tabs: 'true',
-          nav_id: 'myTab',
-          nav_role: 'tablist',
-          nav_items: javascript_items,
-        } %}
-        <div class="tab-content" id="myTabContent">
-          <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">This is home content!</div>
-          <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">This is profile content!</div>
-          <div class="tab-pane fade" id="contact" role="tabpanel" aria-labelledby="contact-tab">This is contact content!</div>
-        </div>
-      </div>
-    {% endblock column_1 %}
-{% endembed %}
+    </div>
+  {% endblock column_1 %}

--- a/source/_patterns/02-molecules/pagination/_pagination.twig
+++ b/source/_patterns/02-molecules/pagination/_pagination.twig
@@ -12,6 +12,7 @@
 {% set pagination_classes = [
   'pagination',
   pagination_size ? 'pagination-' ~ pagination_size,
+  pagination_other_classes,
 ] | sort | join(' ') | trim %}
 
 <nav aria-label="{{ pagination_title }}">

--- a/source/_patterns/03-organisms/accordion/_accordion.twig
+++ b/source/_patterns/03-organisms/accordion/_accordion.twig
@@ -14,6 +14,8 @@
   * https://getbootstrap.com/docs/4.0/components/card/
 #}
 
+{% set accordion_id = random(9999) %}
+
 <div id="{{ 'accordion-' ~ accordion_id }}" role="tablist">
   {% for card in accordion_card_list %}
     {% embed '@molecules/card/_card.twig' %}

--- a/source/_patterns/03-organisms/accordion/_accordion.twig
+++ b/source/_patterns/03-organisms/accordion/_accordion.twig
@@ -14,7 +14,7 @@
   * https://getbootstrap.com/docs/4.0/components/card/
 #}
 
-{% set accordion_id = random(9999) %}
+{% set accordion_id = random() %}
 
 <div id="{{ 'accordion-' ~ accordion_id }}" role="tablist">
   {% for card in accordion_card_list %}

--- a/source/_patterns/03-organisms/accordion/demo/accordions.twig
+++ b/source/_patterns/03-organisms/accordion/demo/accordions.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
 
     <h1>Accordion</h1>
@@ -6,4 +8,3 @@
     {% include '@organisms/accordion/_accordion.twig' with accordion_1 %}
 
   {% endblock %}
-{% endembed %}

--- a/source/_patterns/03-organisms/accordion/demo/accordions.yml
+++ b/source/_patterns/03-organisms/accordion/demo/accordions.yml
@@ -1,5 +1,4 @@
 accordion_1:
-  accordion_id: 1
   accordion_card_list:
     - card_header: 'Collapsible Group Item #1'
       card_text: 'Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor, sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven''t heard of them accusamus labore sustainable VHS.'

--- a/source/_patterns/03-organisms/article/_article.twig
+++ b/source/_patterns/03-organisms/article/_article.twig
@@ -15,8 +15,7 @@
   'img-responsive',
   'rounded-circle',
   'float-right'
-] | join(' ') | trim %}
-
+] | sort | join(' ') | trim %}
 
 <article{{ (BUILD_TARGET == 'pl') ? ' class=' ~ classes : attributes.addClass(classes) }}>
 

--- a/source/_patterns/03-organisms/article/demo/articles.twig
+++ b/source/_patterns/03-organisms/article/demo/articles.twig
@@ -1,4 +1,6 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
+
   {% block column_1 %}
 
     <h1>Article Demonstration</h1>
@@ -8,4 +10,3 @@
     {% include '@organisms/article/_article.twig' with article_1 %}
 
   {% endblock %}
-{% endembed %}

--- a/source/_patterns/03-organisms/card-grid/_card-grid.twig
+++ b/source/_patterns/03-organisms/card-grid/_card-grid.twig
@@ -7,11 +7,12 @@
   see https://getbootstrap.com/docs/4.0/components/card/ for more details
 #}
 
-{% set row_classes = [
+{% set card_grid_classes = [
   'col-sm-12',
   'col-md-6',
   'col-lg-4',
-] | sort | join(' ') | trim ~ row_classes %}
+  row_classes,
+] | sort | join(' ') | trim %}
 
 {% if card_grid_title %}
   <h3>{{ card_grid_title }}</h3>
@@ -29,7 +30,7 @@
         button_link: '#',
       }
     } %}
-  <div class="{{ row_classes }}">
+  <div class="{{ card_grid_classes }}">
     {% include '@molecules/card/_card.twig' with item_card %}
   </div>
   {% endfor %}

--- a/source/_patterns/03-organisms/navbar/demo/navbars.twig
+++ b/source/_patterns/03-organisms/navbar/demo/navbars.twig
@@ -1,17 +1,18 @@
-{% embed '@atoms/grid/_grid-1-up.twig' with { container: true } %}
-    {% block column_1 %}
-      <h1>Navbar</h1>
-      {% include '@molecules/card/_card-helper.twig' with {
-        card_text: navbar_helper,
-        card_background: 'secondary',
-        text_color: 'light',
-        button: {
-          button_link: 'http://getbootstrap.com/docs/4.0/components/navbar/',
-        }
-      } %}
+{% extends '@atoms/grid/_grid-1-up.twig' %}
+  {% set container = true %}
 
-    <div class="mt-3">
-      {% include '@organisms/navbar/_navbar.twig' %}
-    </div>
-    {% endblock column_1 %}
-{% endembed %}
+  {% block column_1 %}
+    <h1>Navbar</h1>
+    {% include '@molecules/card/_card-helper.twig' with {
+      card_text: navbar_helper,
+      card_background: 'secondary',
+      text_color: 'light',
+      button: {
+        button_link: 'http://getbootstrap.com/docs/4.0/components/navbar/',
+      }
+    } %}
+
+  <div class="mt-3">
+    {% include '@organisms/navbar/_navbar.twig' %}
+  </div>
+  {% endblock column_1 %}

--- a/source/_patterns/03-organisms/navbar/demo/navbars.twig
+++ b/source/_patterns/03-organisms/navbar/demo/navbars.twig
@@ -9,7 +9,7 @@
       text_color: 'light',
       button: {
         button_link: 'http://getbootstrap.com/docs/4.0/components/navbar/',
-      }
+      },
     } %}
 
   <div class="mt-3">

--- a/source/_patterns/04-templates/site-container.twig
+++ b/source/_patterns/04-templates/site-container.twig
@@ -1,9 +1,0 @@
-{#{% include '@organisms/header' %}#}
-
-<main class="site-content">
-  {% block content %}
-    <h2>Site Content Here</h2>
-  {% endblock %}
-</main>
-
-{#{% include '@organisms/footer' %}#}

--- a/source/_patterns/05-pages/homepage/homepage.twig
+++ b/source/_patterns/05-pages/homepage/homepage.twig
@@ -1,8 +1,22 @@
-{% extends "@templates/site-container.twig" %}
-{% block content %}
-  <h6>I should fail pa11y</h6>
+{% extends "@templates/homepage/homepage.twig" %}
 
-  <h1 class="homepage__header">this is a pattern lab only demo of the HOMEPAGE</h1>
+  {% block header %}
+    {% embed '@molecules/jumbotron/_jumbotron.twig' with { jumbotron_fluid: true } %}
+      {% block jumbotron_branding %}
+        {% include "@atoms/_branding.twig" with {
+          url: '#',
+          logo_svg_inline: '@atoms/image/logo.svg',
+          site_name: 'Particle',
+          site_slogan: 'An opinionated front-end framework to create design systems.'
+        } %}
+      {% endblock jumbotron_branding %}
+    {% endembed %}
+  {% endblock header %}
 
-  <p class="homepage__text">asdfafdsd blerp</p>
-{% endblock %}
+  {% block content %}
+    <h6>I should fail pa11y</h6>
+
+    <h1 class="homepage__header">this is a pattern lab only demo of the HOMEPAGE</h1>
+
+    <p class="homepage__text">asdfafdsd blerp</p>
+  {% endblock content %}

--- a/source/_patterns/05-pages/homepage/homepage.yml
+++ b/source/_patterns/05-pages/homepage/homepage.yml
@@ -1,0 +1,6 @@
+alert_info:
+  type: 'status'
+  alert_primary: 'This is our homepage!'
+
+footer_content:
+  slogan: 'Powered by <a href="http://patternlab.io/" target="_blank">Pattern Lab</a>'


### PR DESCRIPTION
The PR addresses cleanup tasks:
* Update Demos to Use Extends for Grid
* Update Classes to Use `classes` and `other_classes` with no whitespace
* Update Large Image Style to Constrain with Bootstrap Container
* Remove `site-container.twig` template in favor of `homepage.twig` template.
* Revise ID sets for Carousel and Accordion (moving toward pa11y testing)