### PR TITLE
Feature/v10/plp 35 drupal navbar

### DIFF
--- a/apps/drupal/config/optional/block.block.particle_search.yml
+++ b/apps/drupal/config/optional/block.block.particle_search.yml
@@ -8,7 +8,7 @@ dependencies:
     - views
   theme:
     - particle
-id: particle_search
+id: particle_views_search
 theme: particle
 region: primary_menu
 weight: 0
@@ -19,5 +19,5 @@ settings:
   label: 'Search'
   provider: views
   label_display: '0'
-  views_label: ''
+  views_label: visible
 visibility: {  }

--- a/apps/drupal/config/optional/block.block.particle_searchform.yml
+++ b/apps/drupal/config/optional/block.block.particle_searchform.yml
@@ -15,5 +15,5 @@ settings:
   id: search_form_block
   label: 'Search form'
   provider: search
-  label_display: visible
+  label_display: '0'
 visibility: {  }

--- a/apps/drupal/config/optional/block.block.particle_searchform.yml
+++ b/apps/drupal/config/optional/block.block.particle_searchform.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - search
+  theme:
+    - particle
+id: particle_searchform
+theme: particle
+region: primary_menu
+weight: 0
+provider: null
+plugin: search_form_block
+settings:
+  id: search_form_block
+  label: 'Search form'
+  provider: search
+  label_display: visible
+visibility: {  }

--- a/apps/drupal/config/optional/block.block.particle_searchform.yml
+++ b/apps/drupal/config/optional/block.block.particle_searchform.yml
@@ -8,7 +8,7 @@ dependencies:
 id: particle_searchform
 theme: particle
 region: primary_menu
-weight: 0
+weight: 20
 provider: null
 plugin: search_form_block
 settings:

--- a/apps/drupal/config/optional/block.block.particle_views_search.yml
+++ b/apps/drupal/config/optional/block.block.particle_views_search.yml
@@ -11,7 +11,7 @@ dependencies:
 id: particle_views_search
 theme: particle
 region: primary_menu
-weight: 0
+weight: 20
 provider: null
 plugin: 'views_exposed_filter_block:search-page'
 settings:

--- a/apps/drupal/particle.theme
+++ b/apps/drupal/particle.theme
@@ -5,6 +5,8 @@
  * Functions to support theming in the Particle theme.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
  */

--- a/apps/drupal/particle.theme
+++ b/apps/drupal/particle.theme
@@ -87,3 +87,39 @@ function particle_preprocess_page(&$variables) {
   }
 
 }
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function particle_theme_suggestions_form_alter(array &$suggestions, array $variables) {
+  $id = $variables['element']['#id'];
+  if ($id == 'views-exposed-form-search-page' || $id == 'search-block-form') {
+    $suggestions[] = 'form__particle_search';
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function particle_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Switch method to allow additional cases for these forms.
+  // Let's be explicit because it's easier for newcomers.
+  $id = $form['#id'];
+  switch($id) {
+    case 'views-exposed-form-search-page':
+      // Clean the unwanted label.
+      unset($form['#info']['filter-search_api_fulltext']['label']);
+      // Update type and add Bootstrap classes.
+      $form['keywords']['#type'] = 'search';
+      $form['keywords']['#size'] = 15;
+      $form['keywords']['#title'] = t('Enter the terms you wish to search for.');
+      $form['keywords']['#title_display'] = 'invisible';
+      $form['keywords']['#attributes']['class'] = ['form-control'];
+      $form['actions']['submit']['#attributes']['class'] = ['btn', 'btn-outline-success'];
+      break;
+    case 'search-block-form':
+      // For Drupal's built-in Search, add classes.
+      $form['keys']['#attributes']['class'] = ['form-control'];
+      $form['actions']['submit']['#attributes']['class'] = ['btn', 'btn-outline-success'];
+  }
+}

--- a/apps/drupal/particle.theme
+++ b/apps/drupal/particle.theme
@@ -69,28 +69,6 @@ function particle_preprocess_user(&$variables) {
 }
 
 /**
- * Implements hook_preprocess_page().
- */
-function particle_preprocess_page(&$variables) {
-
-  $messages = [
-    'warning',
-    'status',
-    'error',
-    'info',
-  ];
-
-  foreach ($messages as $message) {
-    drupal_set_message(t('Status: <span>%string</span>',
-      [
-        '%string' => 'This is a ' . $message . ' message. Remove me in particle.theme!',
-      ]
-    ), $message);
-  }
-
-}
-
-/**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function particle_theme_suggestions_form_alter(array &$suggestions, array $variables) {

--- a/apps/drupal/particle.theme
+++ b/apps/drupal/particle.theme
@@ -95,6 +95,9 @@ function particle_preprocess_page(&$variables) {
  */
 function particle_theme_suggestions_form_alter(array &$suggestions, array $variables) {
   $id = $variables['element']['#id'];
+  // Particle Theme for Octane's Views Search and Drupal's Built-In Search.
+  // This hook allows to apply two search block implementations to the same theme file.
+  // Drupal only template file located at /particle/apps/drupal/templates/form/form--particle-search.html.twig.
   if ($id == 'views-exposed-form-search-page' || $id == 'search-block-form') {
     $suggestions[] = 'form__particle_search';
   }
@@ -104,24 +107,36 @@ function particle_theme_suggestions_form_alter(array &$suggestions, array $varia
  * Implements hook_form_alter().
  */
 function particle_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Switch method to allow additional cases for these forms.
-  // Let's be explicit because it's easier for newcomers.
   $id = $form['#id'];
+  // Switch method to allow additional cases for these forms.
+  // We are handling two cases for search block config from Octane and Drupal.
+  // This switch syncs the two radically different render arrays.
   switch($id) {
     case 'views-exposed-form-search-page':
       // Clean the unwanted label.
       unset($form['#info']['filter-search_api_fulltext']['label']);
-      // Update type and add Bootstrap classes.
+      // The Search block from Views doesn't match Drupal's built-in form.
+      // We are syncing them here to make sure they behave the same.
+      // $form['keywords'] is the renderable array for Views Search input field.
+      // Update Views Search input to Search type to avoid offset from input button.
       $form['keywords']['#type'] = 'search';
+      // Update the size of the search field to match Drupal's built-in Search.
       $form['keywords']['#size'] = 15;
+      // Add the title to Views Search for screen readers.
       $form['keywords']['#title'] = t('Enter the terms you wish to search for.');
+      // Set the title to invisible, which applies visually-hidden class for screen reader.
       $form['keywords']['#title_display'] = 'invisible';
+      // Add the Bootstrap class needed for input fields.
       $form['keywords']['#attributes']['class'] = ['form-control'];
+      // Add the Bootstrap class to our Input button.
       $form['actions']['submit']['#attributes']['class'] = ['btn', 'btn-outline-success'];
       break;
     case 'search-block-form':
       // For Drupal's built-in Search, add classes.
+      // $form['keys'] is the renderable array for Drupal's built-in Search input field.
+      // Add the Bootstrap class needed for input fields.
       $form['keys']['#attributes']['class'] = ['form-control'];
+      // Add the Bootstrap class to our Input button.
       $form['actions']['submit']['#attributes']['class'] = ['btn', 'btn-outline-success'];
   }
 }

--- a/apps/drupal/templates/block/block--system-menu-block.html.twig
+++ b/apps/drupal/templates/block/block--system-menu-block.html.twig
@@ -32,6 +32,8 @@
  */
 #}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
+{# block-particle-mainnavigation requires nav to be set in region for Bootstrap's NavBar. #}
+{% if attributes.id != 'block-particle-mainnavigation' %}<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>{% endif %}
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
@@ -39,7 +41,9 @@
   {{ title_prefix }}
   <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
   {{ title_suffix }}
+
   {# Menu. #}
   {% block content %}
     {{ content }}
   {% endblock %}
+  {% if attributes.id != 'block-particle-mainnavigation' %}</nav>{% endif %}

--- a/apps/drupal/templates/block/block--system-menu-block.html.twig
+++ b/apps/drupal/templates/block/block--system-menu-block.html.twig
@@ -31,7 +31,7 @@
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 #}
-{% set heading_id = 'primary-menu' %}
+{% set heading_id = attributes.id ~ '-menu'|clean_id %}
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}

--- a/apps/drupal/templates/block/block--system-menu-block.html.twig
+++ b/apps/drupal/templates/block/block--system-menu-block.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Theme override for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
+{% set heading_id = 'primary-menu' %}
+  {# Label. If not displayed, we still provide it for screen readers. #}
+  {% if not configuration.label_display %}
+    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+  {% endif %}
+  {{ title_prefix }}
+  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  {{ title_suffix }}
+  {# Menu. #}
+  {% block content %}
+    {{ content }}
+  {% endblock %}

--- a/apps/drupal/templates/form/container.html.twig
+++ b/apps/drupal/templates/form/container.html.twig
@@ -19,6 +19,8 @@
  * @see template_preprocess_container()
  */
 #}
+
+{# Update the classes for grouped form items. This adds form-group to our button group for Search. #}
 {%
   set classes = [
     'form-group',

--- a/apps/drupal/templates/form/container.html.twig
+++ b/apps/drupal/templates/form/container.html.twig
@@ -1,0 +1,28 @@
+{#
+/**
+ * @file
+ * Theme override of a container used to wrap child elements.
+ *
+ * Used for grouped form items. Can also be used as a theme wrapper for any
+ * renderable element, to surround it with a <div> and HTML attributes.
+ * See \Drupal\Core\Render\Element\RenderElement for more
+ * information on the #theme_wrappers render array property, and
+ * \Drupal\Core\Render\Element\container for usage of the container render
+ * element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - children: The rendered child elements of the container.
+ * - has_parent: A flag to indicate that the container has one or more parent
+     containers.
+ *
+ * @see template_preprocess_container()
+ */
+#}
+{%
+  set classes = [
+    'form-group',
+    'mx-sm-3',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/apps/drupal/templates/form/form--particle-search.html.twig
+++ b/apps/drupal/templates/form/form--particle-search.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override for a 'form' element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the wrapper element.
+ * - children: The child elements of the form.
+ *
+ * @see template_preprocess_form()
+ */
+#}
+
+{% set classes = [
+  'form-inline',
+] %}
+
+<form{{ attributes.addClass(classes) }}>
+  {{ children }}
+</form>

--- a/apps/drupal/templates/form/form-element.html.twig
+++ b/apps/drupal/templates/form/form-element.html.twig
@@ -1,0 +1,95 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - errors: (optional) Any errors for this form element, may not be set.
+ * - prefix: (optional) The form element prefix, may not be set.
+ * - suffix: (optional) The form element suffix, may not be set.
+ * - required: The required marker, or empty if the associated form element is
+ *   not required.
+ * - type: The type of the element.
+ * - name: The name of the element.
+ * - label: A rendered label element.
+ * - label_display: Label display setting. It can have these values:
+ *   - before: The label is output before the element. This is the default.
+ *     The label includes the #title and the required marker, if #required.
+ *   - after: The label is output after the element. For example, this is used
+ *     for radio and checkbox #type elements. If the #title is empty but the
+ *     field is #required, the label will contain only the required marker.
+ *   - invisible: Labels are critical for screen readers to enable them to
+ *     properly navigate through forms but can be visually distracting. This
+ *     property hides the label for everyone except screen readers.
+ *   - attribute: Set the title attribute on the element to create a tooltip but
+ *     output no label element. This is supported only for checkboxes and radios
+ *     in \Drupal\Core\Render\Element\CompositeFormElementTrait::preRenderCompositeFormElement().
+ *     It is used where a visual label is not needed, such as a table of
+ *     checkboxes where the row and column provide the context. The tooltip will
+ *     include the title and required marker.
+ * - description: (optional) A list of description properties containing:
+ *    - content: A description of the form element, may not be set.
+ *    - attributes: (optional) A list of HTML attributes to apply to the
+ *      description content wrapper. Will only be set when description is set.
+ * - description_display: Description display setting. It can have these values:
+ *   - before: The description is output before the element.
+ *   - after: The description is output after the element. This is the default
+ *     value.
+ *   - invisible: The description is output after the element, hidden visually
+ *     but available to screen readers.
+ * - disabled: True if the element is disabled.
+ * - title_display: Title display setting.
+ *
+ * @see template_preprocess_form_element()
+ */
+#}
+{%
+  set classes = [
+    'form-group',
+    'js-form-item',
+    'form-item',
+    'js-form-type-' ~ type|clean_class,
+    'form-item-' ~ name|clean_class,
+    'js-form-item-' ~ name|clean_class,
+    title_display not in ['after', 'before'] ? 'form-no-label',
+    disabled == 'disabled' ? 'form-disabled',
+    errors ? 'form-item--error',
+  ]
+%}
+{%
+  set description_classes = [
+    'description',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% if label_display in ['before', 'invisible'] %}
+    {{ label }}
+  {% endif %}
+  {% if prefix is not empty %}
+    <span class="field-prefix">{{ prefix }}</span>
+  {% endif %}
+  {% if description_display == 'before' and description.content %}
+    <div{{ description.attributes }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+  {{ children }}
+  {% if suffix is not empty %}
+    <span class="field-suffix">{{ suffix }}</span>
+  {% endif %}
+  {% if label_display == 'after' %}
+    {{ label }}
+  {% endif %}
+  {% if errors %}
+    <div class="form-item--error-message">
+      {{ errors }}
+    </div>
+  {% endif %}
+  {% if description_display in ['after', 'invisible'] and description.content %}
+    <div{{ description.attributes.addClass(description_classes) }}>
+      {{ description.content }}
+    </div>
+  {% endif %}
+</div>

--- a/apps/drupal/templates/form/form-element.html.twig
+++ b/apps/drupal/templates/form/form-element.html.twig
@@ -44,6 +44,8 @@
  * @see template_preprocess_form_element()
  */
 #}
+
+{# Update the classes for form-elements. This only adds form-group to the classes array from Stable's default. #}
 {%
   set classes = [
     'form-group',

--- a/apps/drupal/templates/layout/page.html.twig
+++ b/apps/drupal/templates/layout/page.html.twig
@@ -46,10 +46,7 @@
 
 <div class="layout-container">
 
-  {# @TODO Implement Bootstrap Nav #}
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
-    {{ page.primary_menu }}
-  </nav>
+  {{ page.primary_menu }}
 
   {{ page.highlighted }}
 

--- a/apps/drupal/templates/layout/page.html.twig
+++ b/apps/drupal/templates/layout/page.html.twig
@@ -47,7 +47,9 @@
 <div class="layout-container">
 
   {# @TODO Implement Bootstrap Nav #}
-  {{ page.primary_menu }}
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    {{ page.primary_menu }}
+  </nav>
 
   {{ page.highlighted }}
 

--- a/apps/drupal/templates/layout/region--primary-menu.html.twig
+++ b/apps/drupal/templates/layout/region--primary-menu.html.twig
@@ -23,13 +23,21 @@
 {% if content %}
   {# The Primary Menu region requires our Nav wrapper, which we've removed from block--system-menu-block.html.twig #}
   {# This was done to insure the content array matches what Bootstrap 4 expects - an unordered list representing our menu and the Search block #}
-  <nav role="navigation" aria-labelledby="block-particle-mainnavigation-menu"{{ attributes.addClass(navbar_classes) }}>
-    <a class="navbar-brand" href="{{ url('<front>') }}">{{ 'Particle'|t }}</a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#primary-menu" aria-controls="primary-menu" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-    <div class="collapse navbar-collapse" id="primary-menu">
-      {{ content }}
-    </div>
-  </nav>
+  {% embed '@organisms/navbar/_navbar.twig' %}
+    {% set navbar_arialebelledby = 'block-particle-mainnavigation-menu' %}
+    {% set navbar_attributes = attributes.addClass(navbar_classes) %}
+
+    {% block navbar_brand %}
+      <a class="navbar-brand" href="{{ url('<front>') }}">{{ 'Particle'|t }}</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#primary-menu" aria-controls="primary-menu" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+    {% endblock navbar_brand %}
+    {% block navbar_content %}
+      <div class="collapse navbar-collapse" id="primary-menu">
+        {{ content }}
+      </div>
+    {% endblock navbar_content %}
+
+  {% endembed %}
 {% endif %}

--- a/apps/drupal/templates/layout/region--primary-menu.html.twig
+++ b/apps/drupal/templates/layout/region--primary-menu.html.twig
@@ -16,8 +16,8 @@
 {% set navbar_classes = [
   'navbar',
   'navbar-expand-lg',
-  'navbar-light',
-  'bg-light',
+  'navbar-dark',
+  'bg-dark',
 ] | join(' ') | trim %}
 
 {% if content %}

--- a/apps/drupal/templates/layout/region--primary-menu.html.twig
+++ b/apps/drupal/templates/layout/region--primary-menu.html.twig
@@ -21,6 +21,8 @@
 ] | join(' ') | trim %}
 
 {% if content %}
+  {# The Primary Menu region requires our Nav wrapper, which we've removed from block--system-menu-block.html.twig #}
+  {# This was done to insure the content array matches what Bootstrap 4 expects - an unordered list representing our menu and the Search block #}
   <nav role="navigation" aria-labelledby="block-particle-mainnavigation-menu"{{ attributes.addClass(navbar_classes) }}>
     <a class="navbar-brand" href="{{ url('<front>') }}">{{ 'Particle'|t }}</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#primary-menu" aria-controls="primary-menu" aria-expanded="false" aria-label="Toggle navigation">

--- a/apps/drupal/templates/layout/region--primary-menu.html.twig
+++ b/apps/drupal/templates/layout/region--primary-menu.html.twig
@@ -1,0 +1,33 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region div.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+
+{% set navbar_classes = [
+  'navbar',
+  'navbar-expand-lg',
+  'navbar-light',
+  'bg-light',
+] | join(' ') | trim %}
+
+{% if content %}
+  <nav role="navigation" aria-labelledby="primary-menu"{{ attributes.addClass(navbar_classes) }}>
+    <a class="navbar-brand" href="{{ url('<front>') }}">{{ 'Particle'|t }}</a>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#primary-menu" aria-controls="primary-menu" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="primary-menu">
+      {{ content }}
+    </div>
+  </nav>
+{% endif %}

--- a/apps/drupal/templates/layout/region--primary-menu.html.twig
+++ b/apps/drupal/templates/layout/region--primary-menu.html.twig
@@ -21,7 +21,7 @@
 ] | join(' ') | trim %}
 
 {% if content %}
-  <nav role="navigation" aria-labelledby="primary-menu"{{ attributes.addClass(navbar_classes) }}>
+  <nav role="navigation" aria-labelledby="block-particle-mainnavigation-menu"{{ attributes.addClass(navbar_classes) }}>
     <a class="navbar-brand" href="{{ url('<front>') }}">{{ 'Particle'|t }}</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#primary-menu" aria-controls="primary-menu" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>

--- a/apps/drupal/templates/navigation/menu--footer.html.twig
+++ b/apps/drupal/templates/navigation/menu--footer.html.twig
@@ -1,0 +1,49 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level == 0 %}
+      {# These Classes are added from Particle theme #}
+      <ul{{ attributes.addClass('nav', 'pr-2', 'justify-content-end') }}>
+    {% else %}
+      {# These Classes are added from Particle theme #}
+      <ul class="nav pr-2 justify-content-end">
+    {% endif %}
+    {% for item in items %}
+      <li{{ item.attributes.addClass('nav-item') }}>
+        {{ link(item.title, item.url, item.attributes.addClass('nav-link').removeClass('nav-item')) }}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}

--- a/apps/drupal/templates/navigation/menu--main.html.twig
+++ b/apps/drupal/templates/navigation/menu--main.html.twig
@@ -30,6 +30,7 @@
   {% import _self as menus %}
     {% if items %}
 
+    {# Add wrapper_classes array to style our unordered list below. #}
     {% set wrapper_classes = [
       'navbar-nav',
       'mr-auto',
@@ -43,10 +44,13 @@
 
         {% for item in items %}
 
+          {# Sync Drupal and Bootstrap's active state classes. #}
           {% set item_classes = [
             item.in_active_trail ? 'active',
           ] %}
 
+          {#  Include our pre-built Nav Items from Particle.
+              See particle/source/_patterns/02-molecules/nav/_nav-item.twig. #}
           {% include '@molecules/nav/_nav-item.twig' with {
             nav_item_element: 'li',
             nav_item_classes: item_classes,

--- a/apps/drupal/templates/navigation/menu--main.html.twig
+++ b/apps/drupal/templates/navigation/menu--main.html.twig
@@ -44,30 +44,21 @@
         {% for item in items %}
 
           {% set item_classes = [
-              'nav-item',
-              item.in_active_trail ? 'active',
-            ]
-          %}
+            item.in_active_trail ? 'active',
+          ] %}
 
-          {% set link_classes = [
-              'nav-link',
-            ]
-          %}
+          {% include '@molecules/nav/_nav-item.twig' with {
+            nav_item_element: 'li',
+            nav_item_classes: item_classes,
+            nav_item_link: item.url,
+            js_attributes: item.attributes,
+            nav_item_text: item.title,
+          } %}
 
-          <li{{ item.attributes.addClass(item_classes) }}>
+          {% if item.below %}
+            {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+          {% endif %}
 
-            {{
-              link(
-                item.title,
-                item.url,
-                item.attributes.addClass(link_classes).removeClass(item_classes)
-              )
-            }}
-
-            {% if item.below %}
-              {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
-            {% endif %}
-          </li>
         {% endfor %}
       </ul>
       {% endif %}

--- a/apps/drupal/templates/navigation/menu--main.html.twig
+++ b/apps/drupal/templates/navigation/menu--main.html.twig
@@ -28,22 +28,47 @@
 
 {% macro menu_links(items, attributes, menu_level) %}
   {% import _self as menus %}
-  {% if items %}
+    {% if items %}
+
+    {% set wrapper_classes = [
+      'navbar-nav',
+      'mr-auto',
+    ] | sort | join(' ') | trim %}
+
     {% if menu_level == 0 %}
-      {# These Classes are added from Particle theme #}
-      <ul{{ attributes.addClass('nav', 'pr-2', 'justify-content-end') }}>
-    {% else %}
-      {# These Classes are added from Particle theme #}
-      <ul class="nav pr-2 justify-content-end">
-    {% endif %}
-    {% for item in items %}
-      <li{{ item.attributes.addClass('nav-item') }}>
-        {{ link(item.title, item.url, item.attributes.addClass('nav-link').removeClass('nav-item')) }}
-        {% if item.below %}
-          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+    <ul{{ attributes.addClass(wrapper_classes) }}>
+      {% else %}
+      <ul class="{{ wrapper_classes }}">
         {% endif %}
-      </li>
-    {% endfor %}
-    </ul>
-  {% endif %}
+
+        {% for item in items %}
+
+          {% set item_classes = [
+              'nav-item',
+              item.in_active_trail ? 'active',
+            ]
+          %}
+
+          {% set link_classes = [
+              'nav-link',
+            ]
+          %}
+
+          <li{{ item.attributes.addClass(item_classes) }}>
+
+            {{
+              link(
+                item.title,
+                item.url,
+                item.attributes.addClass(link_classes).removeClass(item_classes)
+              )
+            }}
+
+            {% if item.below %}
+              {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
 {% endmacro %}

--- a/apps/drupal/templates/navigation/menu-local-task.html.twig
+++ b/apps/drupal/templates/navigation/menu-local-task.html.twig
@@ -21,5 +21,4 @@
 ] | join(' ') %}
 
 {# Merge attributes/classes into link for Bootstrap #}
-{# @TODO update to use Preprocess #}
 <li{{ attributes.addClass('nav-item') }}>{{ link|merge({'#options': {'attributes': {'class': link_classes}}}) }}</li>

--- a/source/_patterns/02-molecules/nav/_nav-item.twig
+++ b/source/_patterns/02-molecules/nav/_nav-item.twig
@@ -9,7 +9,7 @@
   nav_item_id: String: The nav item's id html element.
   nav_item_text: String: The nav item's text.
   nav_item_link_classes: Array: The html classes for the nav-item.
-  nav_item_link_other_classes: Array: The classes from YML to merge into nav_item_link_classes.
+  nav_item_link_other_classes: Array: The classes from YAML to merge into nav_item_link_classes.
 #}
 
 {% set nav_item_link = nav_item_link | default('#') %}

--- a/source/_patterns/02-molecules/nav/_nav-item.twig
+++ b/source/_patterns/02-molecules/nav/_nav-item.twig
@@ -8,27 +8,38 @@
   js_attributes: DO NOT SET
   nav_item_id: String: The nav item's id html element.
   nav_item_text: String: The nav item's text.
-  nav_item_link_classes: String: The html classes for the nav-item
+  nav_item_link_classes: Array: The html classes for the nav-item.
+  nav_item_link_other_classes: Array: The classes from YML to merge into nav_item_link_classes.
 #}
 
 {% set nav_item_link = nav_item_link | default('#') %}
 {% set nav_item_element = nav_item_element | default('li') %}
 
+{% set nav_item_classes = nav_item_classes|default([])|merge([
+  'nav-item',
+]) | sort | join(' ') | trim %}
+
+{% set nav_item_link_classes = nav_item_link_other_classes|default([])|merge([
+  'nav-link',
+]) | sort | join(' ') | trim %}
+
 {% if nav_item_js %}
+
   {% set nav_item_aria = (nav_item_link_classes == 'active') ? 'aria-selected="true"' : 'aria-selected="false"' %}
+
   {% set js_attributes = [
     'id="' ~ nav_item_id ~ '"',
     'data-toggle="tab"',
     'role="tab"',
     'aria-controls="' ~ nav_item_text ~ '"',
   ] | sort | join(' ') | trim %}
-  {#test hfref ^#}
+
 {% endif %}
 
 {% if nav_item_element == 'li'  %}
-  <li class="nav-item">
-    <a class="nav-link {{ nav_item_link_classes }}" href="{{ nav_item_link }}" {{ js_attributes }} {{ nav_item_aria }}>{{ nav_item_text }}</a>
+  <li class="{{ nav_item_classes }}">
+    <a class="{{ nav_item_link_classes }}" href="{{ nav_item_link }}" {{ js_attributes }} {{ nav_item_aria }}>{{ nav_item_text }}</a>
   </li>
 {% elseif nav_item_element == 'a' %}
-  <a class="nav-link {{ nav_item_link_classes }}" href="{{ nav_item_link }}">{{ nav_item_text }}</a>
+  <a class="{{ nav_item_link_classes }}" href="{{ nav_item_link }}">{{ nav_item_text }}</a>
 {% endif %}

--- a/source/_patterns/02-molecules/nav/demo/navs.yml
+++ b/source/_patterns/02-molecules/nav/demo/navs.yml
@@ -2,25 +2,38 @@ navs_helper: Documentation and examples for how to use Bootstrap's included navi
 
 nav_items:
   - nav_item_text: Menu
-    nav_item_link_classes: active
+    nav_item_link_other_classes:
+      - active
   - nav_item_text: Menu 2
   - nav_item_text: Menu 3
   - nav_item_text: Menu 4
-    nav_item_link_classes: disabled
+    nav_item_link_other_classes:
+      - disabled
 
 nav_items_responsive:
   - nav_item_text: Menu
-    nav_item_link_classes: flex-sm-fill text-sm-center active
+    nav_item_link_other_classes:
+      - flex-sm-fill
+      - text-sm-center
+      - active
   - nav_item_text: Menu 2
-    nav_item_link_classes: flex-sm-fill text-sm-center
+    nav_item_link_other_classes:
+      - flex-sm-fill
+      - text-sm-center
   - nav_item_text: Menu 3
-    nav_item_link_classes: flex-sm-fill text-sm-center
+    nav_item_link_other_classes:
+      - flex-sm-fill
+      - text-sm-center
   - nav_item_text: Menu 4
-    nav_item_link_classes: flex-sm-fill text-sm-center disabled
+    nav_item_link_other_classes:
+      - flex-sm-fill
+      - text-sm-center
+      - disabled
 
 nav_items_dropdown:
   - nav_item_text: Active
-    nav_item_link_classes: active
+    nav_item_link_other_classes:
+      - active
   - nav_item_dropdown: true
     dropdown_text: Dropdown
     unique_classes: nav-link
@@ -34,13 +47,15 @@ nav_items_dropdown:
       - dropdown_menu_item_text: Another Action
       - dropdown_menu_item_text: Something else here
   - nav_item_text: Link
-    nav_item_link_classes:
+    nav_item_link_other_classes:
   - nav_item_text: Disabled
-    nav_item_link_classes: disabled
+    nav_item_link_other_classes:
+      - disabled
 
 nav_items_javascript:
   - nav_item_text: Home
-    nav_item_link_classes: active
+    nav_item_link_other_classes:
+      - active
     nav_item_id: home-tab
     nav_item_link: '#home'
   - nav_item_text: Profile

--- a/source/_patterns/03-organisms/navbar/_navbar.twig
+++ b/source/_patterns/03-organisms/navbar/_navbar.twig
@@ -1,14 +1,21 @@
 {#
   Navbar!
-  navbar_classes: String: The html classes for the navbar.
+  navbar_classes: Array: The html classes for the navbar.
+  navbar_other_classes: Array: The classes from YAML to merge into navbar_classes.
+  navbar_arialebelledby: String: The aria labelled by value.
+  navbar_attributes: Array: Attributes for the Navbar.
   navbar_brand_link: String: The URL the brand text will link to.
   navbar_brand_text: String: The text of the brand.
   navbar_id: String: The html id for the navbar.
 #}
 
-<nav class="navbar {{ navbar_classes }}">
+{% set navbar_classes = navbar_other_classes|default([])|merge([
+  'navbar',
+]) | sort | join(' ') | trim %}
 
-  {% block brand %}
+<nav role="navigation" aria-labelledby="{{ navbar_arialebelledby }}" {{ navbar_attributes }} class="{{ navbar_classes }}">
+
+  {% block navbar_brand %}
     <a class="navbar-brand" href="{{ navbar_brand_link }}">{{ navbar_brand_text }}</a>
     {# collapse button #}
     {% include '@atoms/button/_button.twig' with {
@@ -18,17 +25,17 @@
       button_other_attributes: 'data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"',
       button_text: '<span class="navbar-toggler-icon"></span>',
     } %}
-  {% endblock brand %}
+  {% endblock navbar_brand %}
 
   {# navbar #}
-  <div class="collapse navbar-collapse" id="{{ navbar_id }}">
-    {% include '@molecules/nav/_nav.twig' with {
-      nav_element: 'ul',
-      nav_other_classes: 'navbar-nav mr-auto',
-      nav_items: navbar_items,
-    } %}
+  {% block navbar_content %}
+    <div class="collapse navbar-collapse" id="{{ navbar_id }}">
+      {% include '@molecules/nav/_nav.twig' with {
+        nav_element: 'ul',
+        nav_other_classes: 'navbar-nav mr-auto',
+        nav_items: navbar_items,
+      } %}
 
-    {% block search %}
       <form class="form-inline my-2 my-lg-0">
         <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
         {% include '@atoms/button/_button.twig' with {
@@ -39,7 +46,7 @@
           button_text: 'Search'
         } %}
       </form>
-    {% endblock search %}
+    </div>
+  {% endblock navbar_content %}
 
-  </div>
 </nav>

--- a/source/_patterns/03-organisms/navbar/demo/navbars.yml
+++ b/source/_patterns/03-organisms/navbar/demo/navbars.yml
@@ -1,6 +1,9 @@
 navbar_helper: Documentation and examples for Bootstrap's powerful, responsive navigation header, the navbar. Includes support for branding, navigation, and more, including support for our collapse plugin.
 
-navbar_classes: navbar-expand-lg navbar-light bg-light
+navbar_other_classes:
+  - navbar-expand-lg
+  - navbar-light
+  - bg-light
 navbar_brand_link: #
 navbar_brand_text: Navbar
 navbar_id: navbarSupportedContent


### PR DESCRIPTION
This PR:
* Adds Search form / config for Views and Search module
* Themes Primary menu region for two blocks: main menu and particle-search(s)

This works in Drupal but I don't think it's completely ready for primetime. But I'm looking to get the conversation started. It's not really extending (yet) from Pattern Lab. Trying to think through how to break apart these elements to extend from PL rather than hardcoding the individual pieces.

Another thing to consider is I'm moving the `<nav>` wrapper element from the `menu--main.html.twig` file to the region file at `region--primary-menu.html.twig`. Doing this in order to make sure the Search form is inside `nav`.