### PR TITLE
Replace black color border for the bootsrap border color variable

### DIFF
--- a/source/_patterns/00-protons/demo/borders.twig
+++ b/source/_patterns/00-protons/demo/borders.twig
@@ -42,8 +42,8 @@
       <p>Add classes to an element to remove all borders or some borders.</p>
       <div class="border">
         {% for class in border_classes %}
-          <span class=" bg-light m-2 border{{ class }}"
-                style="display: inline-block; height: 5rem; width: 5rem; margin: .25rem; border: 1px solid black"></span>
+          <span class=" bg-light m-2 border border{{ class }}"
+                style="display: inline-block; height: 5rem; width: 5rem; margin: .25rem;"></span>
         {% endfor %}
         <pre class="bg-light">
           <code>


### PR DESCRIPTION
Borders here are black. If you define a different color for the $border-color varible it dosen't change because is hardcoded in the inline stye. This prevents the black color and uses whatever the color you define in the $border-color varible.