### PR TITLE
Adds class blockquote to the blockquote in the demo

### DIFF
--- a/source/_patterns/00-protons/demo/type.twig
+++ b/source/_patterns/00-protons/demo/type.twig
@@ -156,7 +156,7 @@
 
       <p>This text is <sub>subscript</sub></p>
 
-      <blockquote>
+      <blockquote class="blockquote">
         <p>A block quotation (also known as a long quotation or extract) is a quotation in a written document, that is set off from the main text as a paragraph, or block of text, and typically distinguished visually using indentation and a different typeface or smaller size quotation.</p>
       </blockquote>
 


### PR DESCRIPTION
Acoording to the [Blockquote documentation](https://getbootstrap.com/docs/4.0/content/typography/#blockquotes) in Bootstrap  is necessary to add the blockquote class. This way it will shows correctly how the blockquote will look like.

Note that in the _type.scss you will edit `.blockquote { }`  and not   the html tag `blockquote`