### PR TITLE
Styleguide: Improving styling on borders proton.

### DIFF
--- a/source/_patterns/00-protons/demo/borders.twig
+++ b/source/_patterns/00-protons/demo/borders.twig
@@ -45,7 +45,7 @@
           <span class=" bg-light m-2 border border{{ class }}"
                 style="display: inline-block; height: 5rem; width: 5rem; margin: .25rem;"></span>
         {% endfor %}
-        <pre class="bg-light">
+        <pre class="bg-light mb-0">
           <code>
 {% for class in border_classes %}
   &lt;span class="border{{ class }}"&gt;&lt;/span&gt;
@@ -61,7 +61,7 @@
                 style="display: inline-block; height: 5rem; width: 5rem; margin: .25rem;"></span>
         {% endfor %}
 
-        <pre class="bg-light">
+        <pre class="bg-light mb-0">
           <code>
 {% for colorName, colorValue in scssColors %}
   &lt;span class="border border-{{ colorName }}"&gt;&lt;/span&gt;
@@ -78,7 +78,7 @@
             class: 'm-2 rounded' ~ class,
           } %}
         {% endfor %}
-        <pre class="bg-light">
+        <pre class="bg-light mb-0">
           <code>
 {% for class in radius_classes %}
   &lt;img src="..." alt="..." class="rounded{{ class }}"&gt;


### PR DESCRIPTION
Improves the appearance of the borders Proton page/element by removing the margin on the `<pre>` that was creating a space after the code samples and before the border supplied by the wrapper element.

### Before: 
<img width="607" alt="screenshot of google chrome 3-15-18 8-51-18 am" src="https://user-images.githubusercontent.com/21905/37465203-e5517ea8-2830-11e8-9480-038376d15297.png">

### After:
<img width="646" alt="screenshot of google chrome 3-15-18 8-51-38 am" src="https://user-images.githubusercontent.com/21905/37465216-ebc82b74-2830-11e8-8080-c6bf10fc397f.png">

I'm starting to test viability of this for a personal project (and future projects) so i'll be submitting some random PRs for visual cleanup of the styleguide defaults. Please let me know if these are wanted/needed. 