### PR TITLE
Update apps/grav/README.md with  correct URL

### DIFF
--- a/apps/grav/README.md
+++ b/apps/grav/README.md
@@ -4,7 +4,7 @@ Particle for Grav is an extension of our opinionated design-system first front-e
 ## Requirements
 
 ### Twig Namespaces Plugin
-See [the repo](https://github.com/phase2/grav-pl-starter/tree/master/app/user/plugins/twig-namespaces) for more information. After installing this plugin in your Grav install, simply copy (or symlink) the included `particle/apps/grav/twig-namespaces.yaml` file to `user/config/plugins/twig-namespaces.yaml` of your Grav install. This covers all patterns / components Particle ships with. This config will need to be updated for any new components you create!
+See [the repo](https://github.com/phase2/grav-plugin-twig-namespaces) for more information. After installing this plugin in your Grav install, simply copy (or symlink) the included `particle/apps/grav/twig-namespaces.yaml` file to `user/config/plugins/twig-namespaces.yaml` of your Grav install. This covers all patterns / components Particle ships with. This config will need to be updated for any new components you create!
 
 Use `namespaces` key as the source of truth. For now a `gulp` task includes a `generated-namespaces` key to output new components. Though not ideal, replace the generated `../..` with `user/themes/particle` to have updated namespaces. Once done, you can replace the `generated-namespaces` key to simply `namespaces`. Make sure to remove the prior version of `namespaces`.
 


### PR DESCRIPTION
Old URL points to missing repo.

Instead, Plugin is now at https://github.com/phase2/grav-plugin-twig-namespaces 

Will need to re-add it to the GravCMS Plugin Repository via this [link](https://github.com/getgrav/grav/issues/new?title=%5Badd-resource%5D%20New%20Plugin%2FTheme&body=I%20would%20like%20to%20add%20my%20new%20plugin%2Ftheme%20to%20the%20Grav%20Repository.%0AHere%20are%20the%20project%20details%3A%20%2A%2Auser%2Frepository%2A%2A)