### PR TITLE
fix naming convention for generating new patterns

### DIFF
--- a/tools/new-component/templates/demo-pattern.js
+++ b/tools/new-component/templates/demo-pattern.js
@@ -5,7 +5,7 @@
  */
 
 // Import component assets
-import '<%= cleanPatternType %>/<%= camelCaseName %>';
+import '<%= cleanPatternType %>/<%= name %>';
 
 // Import demo assets
 import twig from './<%= name %>s.twig';

--- a/tools/new-component/templates/pattern-test.js
+++ b/tools/new-component/templates/pattern-test.js
@@ -1,5 +1,5 @@
 import { name } from '../';
 
 test('<%= name %> component is registered', () => {
-  expect(name).toBe('<%= name %>');
+  expect(name).toBe('<%= camelCaseName %>');
 });


### PR DESCRIPTION
new patterns created with hyphens (e.g. "cool-new-feature") should no longer fail on import or on test.