### PR TITLE
Add root:true to eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@
 module.exports = {
   extends: ['airbnb-base', 'plugin:jest/recommended', 'prettier'],
   plugins: ['prettier'],
+  root: true,
   globals: {
     Drupal: true,
     jQuery: true,


### PR DESCRIPTION
So that eslint will not travel up to parent eslintrc files (say, in Drupal).