### PR TITLE
Set project type to drupal-theme

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,19 @@
 {
     "name": "phase2/particle",
     "description": "A system of tools to build design systems in Pattern Lab for Drupal and Grav.",
-    "type": "project",
-    "license": "GNU General Public License v2.0",
+    "type": "drupal-theme",
+    "license": "GPL-2.0",
+    "homepage": "https://github.com/phase2/particle",
     "authors": [
         {
-            "name": "Christopher Bloom",
+            "name": "Christopher Bloom (illepic)",
             "email": "bloomcb@gmail.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "support": {
+        "docs": "https://phase2.github.io/frontend-docs/",
+        "issues": "https://github.com/phase2/particle/issues",
+        "source": "https://github.com/phase2/particle/tree/master"
+    }
 }


### PR DESCRIPTION
Update composer.json so Particle can be installed as a drupal theme.  Just needed to set the project type to drupal-theme.  This will cause particle to get installed into the themes path for the project.

Also made minor tweaks to the rest of composer to add links for docs etc.