### PR TITLE
Make webpack quieter on prod so easier to spot errors

### DIFF
--- a/apps/drupal/webpack.drupal.js
+++ b/apps/drupal/webpack.drupal.js
@@ -41,7 +41,12 @@ const dev = {
   ],
 };
 
-const prod = {};
+const prod = {
+  stats: {
+    children: false,
+    entrypoints: false,
+  },
+};
 
 module.exports = particle(
   { shared, dev, prod },


### PR DESCRIPTION
This removes all the
```
    Entrypoint mini-css-extract-plugin = *
       2 modules
Child mini-css-extract-plugin node_modules/css-loader/index.js??ref--1-1!node_modules/vue-loader/lib/loaders/stylePostLoader.js!node_modules/postcss-loader/src/index.js??postcss!node_modules/resolve-url-loader/index.js!node_modules/sass-loader/lib/loader.js??ref--1-4!node_modules/vue-loader/lib/index.js??vue-loader-options!source/_patterns/02-molecules/vue-widget/src/vue-cards/components/card.vue?vue&type=style&index=0&id=7f6c7250&lang=scss&scoped=true&:
```
spam at the end of running ``npm run build:drupal`` to make it easier to spot errors without having to scroll a lot.