### PR TITLE
Particle is intended as custom theme, not contrib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "phase2/particle",
     "description": "A system of tools to build design systems in Pattern Lab for Drupal and Grav.",
-    "type": "drupal-theme",
+    "type": "drupal-custom-theme",
     "license": "GPL-2.0",
     "homepage": "https://github.com/phase2/particle",
     "authors": [


### PR DESCRIPTION
Using the "drupal-theme" composer type causes Particle to be placed within /themes/contrib. Since Particle is used as the template for a *custom* theme, need to change it to "drupal-custom-theme" so it can be placed within themes/custom.