### PR TITLE
Adjust PL webpack to work with docker containers

### DIFF
--- a/apps/pl/webpack.pl.js
+++ b/apps/pl/webpack.pl.js
@@ -68,7 +68,8 @@ const dev = {
   devServer: {
     host: '0.0.0.0',
     port: '8080',
-    contentBase: PATH_DIST, // dev server starts from this folder.
+    allowedHosts: ['.docksal', '.vm', '0.0.0.0', 'localhost'],
+    contentBase: path.resolve('dist/pl/'), // dev server starts from this folder.
     watchContentBase: true, // Refresh devServer when dist/ changes (Pattern Lab)
     watchOptions: {
       ignored: '/(node_modules|dist/pl)/',

--- a/apps/pl/webpack.pl.js
+++ b/apps/pl/webpack.pl.js
@@ -69,7 +69,7 @@ const dev = {
     host: '0.0.0.0',
     port: '8080',
     allowedHosts: ['.docksal', '.vm', '0.0.0.0', 'localhost'],
-    contentBase: path.resolve('dist/pl/'), // dev server starts from this folder.
+    contentBase: PATH_DIST, // dev server starts from this folder.
     watchContentBase: true, // Refresh devServer when dist/ changes (Pattern Lab)
     watchOptions: {
       ignored: '/(node_modules|dist/pl)/',


### PR DESCRIPTION
When accessing PL from a docker container, we are using domains such as "design.project.docksal" or "design.project.vm" (Docksal or Outrigger) so need to adjust the allowedHosts for those domains.

Also, the DIST_PATH doesn't seem to work so changed to use ``path.resolve('dist/pl/')`` for the contentBase instead which seems to work in docker, but this should be tested for local non-docker devs.