### PR TITLE
Add environment variable to override local webserver host name

### DIFF
--- a/apps/pl/webpack.pl.js
+++ b/apps/pl/webpack.pl.js
@@ -16,7 +16,7 @@ const RunScriptOnFiletypeChange = require('../../tools/webpack/run-script-on-fil
 const particle = require('../../particle');
 
 // Constants
-const { NODE_ENV } = process.env;
+const { NODE_ENV, PUBLIC_HOST = '' } = process.env;
 const { PATH_SOURCE, PATH_DIST } = require('../../config');
 
 const shared = {
@@ -63,6 +63,7 @@ const dev = {
     port: '8080',
     allowedHosts: ['.docksal', '.vm', '0.0.0.0', 'localhost'],
     contentBase: PATH_DIST, // dev server starts from this folder.
+    public: PUBLIC_HOST, // local host name for devServer
     watchContentBase: true, // Refresh devServer when dist/ changes (Pattern Lab)
     watchOptions: {
       ignored: '/(node_modules|dist/pl)/',


### PR DESCRIPTION
Adding the new PUBLIC_HOST environment variable so we can override the url webpack uses to refresh the browser on changes.  Defaulting to "" seems to work fine for local server.  Will use this with Docksal and Outrigger to update design.project.docksal or design.project.vm.