### PR TITLE
Components Error Handling and Page

### DIFF
--- a/apps/drupal/particle.theme
+++ b/apps/drupal/particle.theme
@@ -13,7 +13,7 @@ use Drupal\Core\Form\FormStateInterface;
 function particle_preprocess_page(&$variables) {
   $moduleHandler = \Drupal::service('module_handler');
   if ($moduleHandler->moduleExists('components')){
-    $variables['components'] = TRUE;
+    $variables['has_components_module'] = TRUE;
   }
 }
 

--- a/apps/drupal/particle.theme
+++ b/apps/drupal/particle.theme
@@ -8,6 +8,16 @@
 use Drupal\Core\Form\FormStateInterface;
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function particle_preprocess_page(&$variables) {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('components')){
+    $variables['components'] = TRUE;
+  }
+}
+
+/**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function particle_theme_suggestions_block_alter(array &$suggestions, array $variables) {

--- a/apps/drupal/templates/layout/components--error-message.html.twig
+++ b/apps/drupal/templates/layout/components--error-message.html.twig
@@ -41,7 +41,7 @@ body {
 </style>
 
 <div class="components_error">
-  <h1 class="components_error--blinker">CRITIAL FAILURE OMG</h1>
+  <h1 class="components_error--blinker">CRITICAL FAILURE OMG</h1>
   <p>It looks like you forgot to install the  <a href="https://www.drupal.org/project/components">Component Libraries</a> module. Please install it and come back! Have a great day!</p>
 </div>
 <img class="components_error--image" src="https://media1.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif?cid=3640f6095bbff9f35873486a55d52ada" alt="funny cat GIF">

--- a/apps/drupal/templates/layout/components--error-message.html.twig
+++ b/apps/drupal/templates/layout/components--error-message.html.twig
@@ -1,0 +1,47 @@
+{#
+/**
+ * @file
+ * Theme to display an error page for missing the Component Libraries module.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+
+<style>
+@import url('https://fonts.googleapis.com/css?family=Roboto+Condensed');
+body {
+  background-color: goldenrod;
+  font-family: 'Roboto Condensed', sans-serif;
+}
+
+.components_error {
+  width: 50%;
+  padding: 0 10% 0 10%;
+  margin: auto;
+}
+
+.components_error--image {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  width: 50%;
+}
+
+.components_error--blinker {
+  animation: blinker 1s linear infinite;
+  color: #102E37;
+}
+
+@keyframes blinker {
+  50% {
+    opacity: 0;
+  }
+}
+</style>
+
+<div class="components_error">
+  <h1 class="components_error--blinker">CRITIAL FAILURE OMG</h1>
+  <p>It looks like you forgot to install the  <a href="https://www.drupal.org/project/components">Component Libraries</a> module. Please install it and come back! Have a great day!</p>
+</div>
+<img class="components_error--image" src="https://media1.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif?cid=3640f6095bbff9f35873486a55d52ada" alt="funny cat GIF">

--- a/apps/drupal/templates/layout/page.html.twig
+++ b/apps/drupal/templates/layout/page.html.twig
@@ -9,6 +9,7 @@
  * Available variables:
  *
  * General utility variables:
+ * - components: The boolean value of the components module requirement.
  * - base_path: The base URL path of the Drupal installation. Will usually be
  *   "/" unless you have installed Drupal in a sub-directory.
  * - is_front: A flag indicating if the current page is the front page.
@@ -44,6 +45,9 @@
  */
 #}
 
+{% if not components %}
+  {% include '@particle/layout/components--error-message.html.twig' %}
+{% else %}
 <div class="layout-container">
 
   {{ page.primary_menu }}
@@ -98,3 +102,4 @@
   <hr>
   {{ page.footer }}
 </footer>
+{% endif %}

--- a/apps/drupal/templates/layout/page.html.twig
+++ b/apps/drupal/templates/layout/page.html.twig
@@ -9,7 +9,7 @@
  * Available variables:
  *
  * General utility variables:
- * - components: The boolean value of the components module requirement.
+ * - has_components_module: The boolean value of the components module requirement.
  * - base_path: The base URL path of the Drupal installation. Will usually be
  *   "/" unless you have installed Drupal in a sub-directory.
  * - is_front: A flag indicating if the current page is the front page.

--- a/apps/drupal/templates/layout/page.html.twig
+++ b/apps/drupal/templates/layout/page.html.twig
@@ -45,7 +45,7 @@
  */
 #}
 
-{% if not components %}
+{% if not has_components_module %}
   {% include '@particle/layout/components--error-message.html.twig' %}
 {% else %}
 <div class="layout-container">

--- a/apps/drupal/templates/layout/page.html.twig
+++ b/apps/drupal/templates/layout/page.html.twig
@@ -46,7 +46,7 @@
 #}
 
 {% if not has_components_module %}
-  {% include '@particle/layout/components--error-message.html.twig' %}
+  {% include '@particle/misc/components--error-message.html.twig' %}
 {% else %}
 <div class="layout-container">
 

--- a/apps/drupal/templates/misc/components--error-message.html.twig
+++ b/apps/drupal/templates/misc/components--error-message.html.twig
@@ -9,10 +9,10 @@
 #}
 
 <style>
-@import url('https://fonts.googleapis.com/css?family=Roboto+Condensed');
+
 body {
   background-color: goldenrod;
-  font-family: 'Roboto Condensed', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
 }
 
 .components_error {

--- a/apps/drupal/templates/misc/components--error-message.html.twig
+++ b/apps/drupal/templates/misc/components--error-message.html.twig
@@ -41,7 +41,7 @@ body {
 </style>
 
 <div class="components_error">
-  <h1 class="components_error--blinker">CRITICAL FAILURE OMG</h1>
-  <p>It looks like you forgot to install the  <a href="https://www.drupal.org/project/components">Component Libraries</a> module. Please install it and come back! Have a great day!</p>
+  <h1 class="components_error--blinker">{{ 'CRITICAL FAILURE OMG'|t }}</h1>
+  <p class="components_error--body">{{ 'It looks like you forgot to install the <a href=":url">Component Libraries</a> module. Please install it and come back! Have a great day!'|t({ ':url': 'https://www.drupal.org/project/components' }) }}</p>
 </div>
-<img class="components_error--image" src="https://media1.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif?cid=3640f6095bbff9f35873486a55d52ada" alt="funny cat GIF">
+<img class="components_error--image" src="https://media1.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif?cid=3640f6095bbff9f35873486a55d52ada" alt="{{ 'funny cat GIF'|t }}">


### PR DESCRIPTION
See Issue https://github.com/phase2/particle/issues/426

This PR adds a generic template variable that checks whether or not the Component Libraries module is installed. If not, the page is redirected to a more "helpful" error page.