### PR TITLE
Add pl-paths.js tool

### DIFF
--- a/tools/pl-paths.js
+++ b/tools/pl-paths.js
@@ -1,0 +1,18 @@
+//run by typing : node tools/pl-paths.js
+
+const plData = require('../dist/pl/styleguide/data/patternlab-data.json');
+const particles = [
+  'protons',
+  'atoms',
+  'molecules',
+  'organisms',
+  'templates',
+  'pages',
+];
+let paths = [];
+
+particles.forEach(particle => {
+  const urls = Object.values(plData.patternPaths[particle]);
+  paths = paths.concat(urls);
+});
+console.log(paths);

--- a/tools/pl-paths.js
+++ b/tools/pl-paths.js
@@ -1,11 +1,9 @@
-// run with : node tools/pl-paths.js
-
 const {
   patternPaths,
 } = require('../dist/pl/styleguide/data/patternlab-data.json');
 
-// Concats and spreads all urls of the atomic particles that exist
-// in the project.
+// Returns an array of urls for the particles that exist
+// in a particle project.
 // Example output:
 // [
 //   '00-protons-demo-borders',

--- a/tools/pl-paths.js
+++ b/tools/pl-paths.js
@@ -1,18 +1,11 @@
-//run by typing : node tools/pl-paths.js
+//run with : node tools/pl-paths.js
 
 const plData = require('../dist/pl/styleguide/data/patternlab-data.json');
-const particles = [
-  'protons',
-  'atoms',
-  'molecules',
-  'organisms',
-  'templates',
-  'pages',
-];
+const particles = Object.keys(plData.patternPaths);
 let paths = [];
 
 particles.forEach(particle => {
   const urls = Object.values(plData.patternPaths[particle]);
-  paths = paths.concat(urls);
+  paths.push(...urls);
 });
 console.log(paths);

--- a/tools/pl-paths.js
+++ b/tools/pl-paths.js
@@ -2,13 +2,15 @@ const {
   patternPaths,
 } = require('../dist/pl/styleguide/data/patternlab-data.json');
 
-// Returns an array of urls for the particles that exist
-// in a particle project.
+// Returns an array of urls for the patterns that exist
+// in a pattern lab project.
 // Example output:
 // [
 //   '00-protons-demo-borders',
 //   '00-protons-demo-breakpoints',
 // ]
 module.exports = [].concat(
-  ...Object.keys(patternPaths).map(url => Object.values(patternPaths[url]))
+  ...Object.keys(patternPaths).map(pattern =>
+    Object.values(patternPaths[pattern])
+  )
 );

--- a/tools/pl-paths.js
+++ b/tools/pl-paths.js
@@ -2,7 +2,7 @@
 
 const plData = require('../dist/pl/styleguide/data/patternlab-data.json');
 const particles = Object.keys(plData.patternPaths);
-let paths = [];
+const paths = [];
 
 particles.forEach(particle => {
   const urls = Object.values(plData.patternPaths[particle]);

--- a/tools/pl-paths.js
+++ b/tools/pl-paths.js
@@ -1,11 +1,16 @@
-//run with : node tools/pl-paths.js
+// run with : node tools/pl-paths.js
 
-const plData = require('../dist/pl/styleguide/data/patternlab-data.json');
-const particles = Object.keys(plData.patternPaths);
-const paths = [];
+const {
+  patternPaths,
+} = require('../dist/pl/styleguide/data/patternlab-data.json');
 
-particles.forEach(particle => {
-  const urls = Object.values(plData.patternPaths[particle]);
-  paths.push(...urls);
-});
-console.log(paths);
+// Concats and spreads all urls of the atomic particles that exist
+// in the project.
+// Example output:
+// [
+//   '00-protons-demo-borders',
+//   '00-protons-demo-breakpoints',
+// ]
+module.exports = [].concat(
+  ...Object.keys(patternPaths).map(url => Object.values(patternPaths[url]))
+);


### PR DESCRIPTION
This module will return an array of all pattern urls of a pattern lab project.  This will be helpful for gathering url paths that can be used with automated testing tools like pa11y and BackstopJS.