### PR TITLE
Add a tool for retrieving an array of paths from Pattern Lab

### DIFF
--- a/tools/pl-paths.js
+++ b/tools/pl-paths.js
@@ -1,0 +1,16 @@
+/* This script outputs an array of all the url paths within Pattern Lab.
+This array of paths will be useful for testing tools such as BackstopJS and Pa11y by running
+those paths for testing to help ensure accessibility.
+*/
+
+const {
+  patternPaths,
+} = require('../dist/pl/styleguide/data/patternlab-data.json');
+
+const paths = [].concat(
+  ...Object.values(patternPaths).map(particle => Object.values(particle))
+);
+
+console.log(paths);
+
+module.exports = paths;


### PR DESCRIPTION
Hey @illepic , 
I saw in the PR (pa11y update #431) that there is an additional map method `Object.values(atomic).map(path => path)` but mine seems to be working without it and it doesn't seem necessary. 
Can you please take a look and let me know what you think?