### PR TITLE
Fix Pa11y config and add contrast ratio rules to ignore

### DIFF
--- a/tools/tests/accessibility/pa11y.js
+++ b/tools/tests/accessibility/pa11y.js
@@ -8,15 +8,15 @@ const urls = htmlPaths.map(partial => `${plRoot}/${partial}`);
 // See pa11y config https://github.com/pa11y/pa11y-ci#usage
 module.exports = {
   standard: 'WCAG2AAA',
-  ignore: [
-    'WCAG2AAA.Principle3.Guideline3_1.3_1_1.H57.2',
-    'WCAG2AAA.Principle1.Guideline1_4.1_4_6.G18',
-  ],
   defaults: {
     concurrency: 5,
     timeout: 20000,
     wait: 2000,
-    ignore: [],
+    ignore: [
+      'WCAG2AAA.Principle3.Guideline3_1.3_1_1.H57.2',
+      'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail',
+      'WCAG2AA.Principle1.Guideline1_4.1_4_3.G145.Fail',
+    ],
   },
   urls,
 };


### PR DESCRIPTION
Hey @illepic --it appears that in the Pa11y documentation, the list of HTML CodeSniffer rules used is incomplete and missing the .Fail to the end of those contrast rules. Also, after reading further the documentation, I found out that the ignore array needs to be inside of the defaults object.