### PR TITLE
Fix SVG icons sizing issue

### DIFF
--- a/source/default/_patterns/00-protons/non-printing/_functions.scss
+++ b/source/default/_patterns/00-protons/non-printing/_functions.scss
@@ -18,7 +18,7 @@
  * Numbers are space delimited. If you want to delimit using commas, wrap it in another pair of parens.
  * @example rem-calc((10, 20, 30, 40px));
  */
-@function rem-calc($values, $base-value: $font-size-base) {
+@function rem-calc($values, $base-value: 16px) {
   $max: length($values);
 
   @if $max == 1 { @return convert-to-rem(nth($values, 1), $base-value); }


### PR DESCRIPTION
Hey @illepic and @Jwaxo --looks like this issue has been discussed in the past( #423 ) but the
way it is currently implemented is broken. The value of [$font-size-base](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_variables.scss) is 1rem instead of the value that is meant to be which is 16px, at least the way it is implemented there. This is my suggestion for the fix but y'all can provide other ideas.
In ref to issue: #475