### PR TITLE
Replace console.log with this.log in component generator

### DIFF
--- a/tools/new-component/index.js
+++ b/tools/new-component/index.js
@@ -57,7 +57,7 @@ const prompts = [
 
 module.exports = class extends Generator {
   prompting() {
-    console.log(
+    this.log(
       `Hi! This will help you build a component folder with assets.
       Templates for this are in: ${relative(process.cwd(), __dirname)}`
     );
@@ -143,7 +143,7 @@ module.exports = class extends Generator {
       });
     });
 
-    console.log(
+    this.log(
       `Your new component ${name} is being created. It should be available in your bundle!`
     );
   }


### PR DESCRIPTION
Per the Yeoman docs https://yeoman.io/authoring/user-interactions.html

> For example, it is important to never use console.log() or process.stdout.write() to output content. Using them would hide the output from users not using a terminal. Instead, always rely on the UI generic this.log() method, where this is the context of your current generator.