### PR TITLE
501: Missing card-grid in dist/app-drupal causes components library error

### DIFF
--- a/apps/drupal/templates/layout/region--primary-menu.html.twig
+++ b/apps/drupal/templates/layout/region--primary-menu.html.twig
@@ -21,8 +21,12 @@
 ] | join(' ') | trim %}
 
 {% if content %}
-  {# The Primary Menu region requires our Nav wrapper, which we've removed from block--system-menu-block.html.twig #}
-  {# This was done to insure the content array matches what Bootstrap 4 expects - an unordered list representing our menu and the Search block #}
+  {#
+  The Primary Menu region requires our Nav wrapper, which we've removed from
+  block--system-menu-block.html.twig. This was done to ensure the content array
+  matches what Bootstrap 4 expects - an unordered list representing our menu and
+  the Search block.
+  #}
   {% embed '@organisms/navbar/_navbar.twig' %}
     {% set navbar_arialebelledby = 'block-particle-mainnavigation-menu' %}
     {% set navbar_attributes = attributes.addClass(navbar_classes) %}

--- a/source/default/_patterns/03-organisms/card-grid/index.js
+++ b/source/default/_patterns/03-organisms/card-grid/index.js
@@ -1,0 +1,13 @@
+/**
+ * Card Grid
+ */
+
+import './_card-grid.twig';
+
+export const name = 'card-grid';
+
+export function disable() {}
+
+export function enable() {}
+
+export default enable;


### PR DESCRIPTION
Any missing sub-folder within a namespace causes the Drupal Components module to throw away the entire namespace.

card-grid was not being copied over to dist/app-drupal due to a missing index.js file, therefore drupal couldn't find it therefore components threw away all organisms.