### PR TITLE
chore: only output twig-lint errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "scripts": {
         "twig-lint": [
-            "twig-lint --ansi"
+            "twig-lint --ansi --only-print-errors"
         ]
     }
 }


### PR DESCRIPTION
This [undocumented](https://github.com/asm89/twig-lint/issues/29) flag prevents the output of all the "OK in ./path/to/file.twig". Was poking around your code and felt like sharing back; hope your days are all awesome! 