### PR TITLE
Add url-loader limit to font file packing

### DIFF
--- a/webpack.particle.js
+++ b/webpack.particle.js
@@ -109,10 +109,19 @@ module.exports = {
         },
       },
       {
+        // base64 encode all referenced font files for simple loading.
         test: /\.(woff|woff2|eot|ttf)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
         use: [
           {
             loader: 'url-loader',
+            options: {
+              limit: 50000,
+
+              // If a font file is over 50k, output below fonts directory.
+              // This prevents massive .css file bloat.
+              name: '[name].[ext]',
+              outputPath: 'fonts/',
+            },
           },
         ],
       },


### PR DESCRIPTION
When more than a few small custom fonts are included the resulting app.styles.css files can get prohibitively large. This tweak checks font files with url-loader prior to base64 encoding them into the resulting .css, and instead just copies and references the font file into a `font` folder. Since `resolve-url-loader` is already included, the moving shouldn't matter.