### PR TITLE
Update bootstrap spacer override and better document usage

### DIFF
--- a/source/default/_data/scssVariables.json
+++ b/source/default/_data/scssVariables.json
@@ -24,10 +24,8 @@
     "2": "0.5rem",
     "3": "1rem",
     "4": "1.5rem",
-    "5": "2rem",
-    "6": "2.5rem",
-    "7": "3rem",
-    "8": "4rem"
+    "5": "3rem",
+    "6": "4rem"
   },
   "fontFamilies": {
     "$font-family-base": [

--- a/source/default/_data/scssVariables.json
+++ b/source/default/_data/scssVariables.json
@@ -24,9 +24,10 @@
     "2": "0.5rem",
     "3": "1rem",
     "4": "1.5rem",
-    "5": "3rem",
-    "6": "3.5rem",
-    "7": "4rem"
+    "5": "2rem",
+    "6": "2.5rem",
+    "7": "3rem",
+    "8": "4rem"
   },
   "fontFamilies": {
     "$font-family-base": [

--- a/source/default/_patterns/00-protons/demo/spacing.twig
+++ b/source/default/_patterns/00-protons/demo/spacing.twig
@@ -3,14 +3,14 @@
     <div class="col mt-sm-5">
 
       <h1>Spacing</h1>
-      <p class="lead">To add to these items, adjust <code>$spacers()</code> in <code>non-printing/_bootstrap-overrides.scss</code>.</p>
-      <p><code>$spacers(0)</code> produces a value of <code>0</code> and is allowed but not shown in this demo.</p>
+      <p class="lead">To add to these items, adjust <code>spacers()</code> in <code>non-printing/_bootstrap-overrides.scss</code>.</p>
+      <p><code>spacers(0)</code> produces a value of <code>0</code> and is allowed but not shown in this demo.</p>
       <p>The math for rem calculations here is based on a browser value of 16px as a <code>$spacer</code> value. To find out your spacer in pixels, simply multiply the rem value in the spacers list by this spacer value. For example, a 1.5rem value in <code>$spacers</code> is equivalent to 24px.</p>
       {% for spacer, value in scssSpacing %}
         {% if spacer != 0 %}
           <div style="margin: 10px;">
             <div style="height: {{ value }}; width: {{ value }}; outline: solid 1px black; display: inline-block; margin-right: 5px;"></div>
-            <span>{{ value }} : <code>$spacers({{ spacer }})</code></span>
+            <span>{{ value }} : <code>spacers({{ spacer }})</code></span>
           </div>
         {% endif %}
       {% endfor %}

--- a/source/default/_patterns/00-protons/demo/spacing.twig
+++ b/source/default/_patterns/00-protons/demo/spacing.twig
@@ -5,6 +5,7 @@
       <h1>Spacing</h1>
       <p class="lead">To add to these items, adjust <code>$spacers()</code> in <code>non-printing/_bootstrap-overrides.scss</code>.</p>
       <p><code>$spacers(0)</code> produces a value of <code>0</code> and is allowed but not shown in this demo.</p>
+      <p>The math for rem calculations here is based on a browser value of 16px as a <code>$spacer</code> value. To find out your spacer in pixels, simply multiply the rem value in the spacers list by this spacer value. For example, a 1.5rem value in <code>$spacers</code> is equivalent to 24px.</p>
       {% for spacer, value in scssSpacing %}
         {% if spacer != 0 %}
           <div style="margin: 10px;">

--- a/source/default/_patterns/00-protons/non-printing/_bootstrap-overrides.scss
+++ b/source/default/_patterns/00-protons/non-printing/_bootstrap-overrides.scss
@@ -18,17 +18,11 @@ $card-border-width: rem-calc(1px);
 
 // Spacing
 // Bootstrap Spacers use $spacer var of 1rem and assumes browser 16px default.
+// Updating the values in $spacers list adds the value to Bootstrap's utility spacers.
+// Example, the below adds a mb-6 utility spacing class.
 $spacer: 1rem;
 $spacers: (
-  0: 0, // 0px
-  1: ($spacer * .25), // 4px
-  2: ($spacer * .5), // 8px
-  3: $spacer, // 16px
-  4: ($spacer * 1.5), // 24px
-  5: ($spacer * 2), // 32px
-  6: ($spacer * 2.5), // 40px
-  7: ($spacer * 3), // 48px
-  8: ($spacer * 4), // 64px
+  6: ($spacer * 4), // 64px
 );
 
 // Bootstrap non-printing tools. DO NOT REMOVE, because Sass overrides must be

--- a/source/default/_patterns/00-protons/non-printing/_bootstrap-overrides.scss
+++ b/source/default/_patterns/00-protons/non-printing/_bootstrap-overrides.scss
@@ -17,9 +17,18 @@ $btn-border-radius: 0.25rem;
 $card-border-width: rem-calc(1px);
 
 // Spacing
+// Bootstrap Spacers use $spacer var of 1rem and assumes browser 16px default.
+$spacer: 1rem;
 $spacers: (
-  6: 1rem * 3.5,
-  7: 1rem * 4,
+  0: 0, // 0px
+  1: ($spacer * .25), // 4px
+  2: ($spacer * .5), // 8px
+  3: $spacer, // 16px
+  4: ($spacer * 1.5), // 24px
+  5: ($spacer * 2), // 32px
+  6: ($spacer * 2.5), // 40px
+  7: ($spacer * 3), // 48px
+  8: ($spacer * 4), // 64px
 );
 
 // Bootstrap non-printing tools. DO NOT REMOVE, because Sass overrides must be

--- a/source/default/_patterns/00-protons/non-printing/_functions.scss
+++ b/source/default/_patterns/00-protons/non-printing/_functions.scss
@@ -38,3 +38,22 @@
   }
   @return $remValues;
 }
+
+/**
+ * A function to reliably retrieve the value of a Bootstrap $spacers list.
+ *
+ * @param $key
+ *   The key in the Bootstrap spacers list you wish to access.
+ *
+ * @example spacers(1);
+ *
+ */
+@function spacers($key) {
+  @if map-has-key($spacers, $key) {
+    @return map-get($spacers, $key);
+  }
+
+  @warn "Unknown `#{$key}` in $spacers.";
+
+  @return null;
+}


### PR DESCRIPTION
This PR refactors our Bootstrap approach for spacers. Rather than simply append, override the entirety of the list to better show off what's going on. This change also includes a blurb in the demo proton to give devs a better idea how to use this in place of static pixel values.

Note that this may negatively impact some default patterns. Any that previously used spacers 5-7 may need supplemental updates.
