### PR TITLE
Ignore vendor directory in eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@
 
 dist/
 pattern-lab/
+vendor/
 
 # Ignore yeoman new-component templates
 tools/new-component/templates

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,6 +1,7 @@
 # Ignore any path/file using .gitignore syntax, ie:
 
 node_modules/
+vendor/
 
 dist/
 pattern-lab/


### PR DESCRIPTION
Since these are used in development of particle itself, it is safe to remove them when folks install this for actual use.