### PR TITLE
Allows the pa11y domain to be overridden via a variable.

### DIFF
--- a/tools/tests/accessibility/pa11y.js
+++ b/tools/tests/accessibility/pa11y.js
@@ -1,11 +1,10 @@
 // All non-protons PL paths
 const { componentPaths } = require('../../pl-paths.js');
 
+const { PL_BASE_DOMAIN } = process.env;
+
 // The PL_BASE_DOMAIN environment variable should be set to override the default.
-let plRootDomain = '0.0.0.0:8080';
-if (process.env.PL_BASE_DOMAIN) {
-  plRootDomain = process.env.PL_BASE_DOMAIN;
-}
+const plRootDomain = PL_BASE_DOMAIN || '0.0.0.0:8080';
 const plRoot = `http://${plRootDomain}/app-pl/pl`;
 
 // urls comes from particle, includes all demo paths from atoms+

--- a/tools/tests/accessibility/pa11y.js
+++ b/tools/tests/accessibility/pa11y.js
@@ -1,7 +1,12 @@
 // All non-protons PL paths
 const { componentPaths } = require('../../pl-paths.js');
 
-const plRoot = 'http://0.0.0.0:8080/app-pl/pl'; // @TODO: move this to config
+// The PL_BASE_DOMAIN environment variable should be set to override the default.
+let plRootDomain = '0.0.0.0:8080';
+if (process.env.PL_BASE_DOMAIN) {
+  plRootDomain = process.env.PL_BASE_DOMAIN;
+}
+const plRoot = `http://${plRootDomain}/app-pl/pl`;
 
 // urls comes from particle, includes all demo paths from atoms+
 let urls = componentPaths.map(partial => `${plRoot}/${partial}`);


### PR DESCRIPTION
This allows `pa11y` to run in GitLab, within Docker locally, etc.