### PR TITLE
Enable twig dump() function by default for debugging.

### DIFF
--- a/apps/node-pl/patternlab-config.json
+++ b/apps/node-pl/patternlab-config.json
@@ -181,7 +181,8 @@
           "file": "./apps/node-pl/pattern-lab/alter-twig.php",
           "functions": [
             "addFilters",
-            "addFunctions"
+            "addFunctions",
+            "addDebug"
           ]
         }
       ]


### PR DESCRIPTION
I've gotten accustomed to using the dump() function exclusively in Drupal and would like to see this enabled by default in Particle for debugging purposes.