### PR TITLE
Set correct value for the `plRoot` variable

### DIFF
--- a/tools/tests/vrt/backstop-example-settings.js
+++ b/tools/tests/vrt/backstop-example-settings.js
@@ -6,7 +6,7 @@
 
 const { partials } = require('../../pl-paths.js');
 
-const plRoot = 'http://0.0.0.0:8080/app-pl/pl';
+const plRoot = 'http://0.0.0.0:8080/app-node-pl/pl';
 
 module.exports = () => {
   // Set which resolutions to take screenshots at.


### PR DESCRIPTION
This variable is set to the old path for the Pattern Lab instance.
As this variable is appended with the component paths and used to
create URLs for BackstopJS scenarios, it causes problems. Namely
no reference could be created properly.

This fixes the problem.

Related issue: #798 