### PR TITLE
Remove reference to composer.json in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,3 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
-
-[composer.{json,lock}]
-indent_size = 4


### PR DESCRIPTION
# Pull Request

## Issue Description

`.editorconfig` still references composer.json

## Summary of Changes

Removed refs to composer.json in editorconfig
