### PR TITLE
Adding shareable eslint rules

### DIFF
--- a/packages/eslint-config/cypress.js
+++ b/packages/eslint-config/cypress.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: ['.index.js'],
+  plugins: ['cypress'],
+  env: {
+    'cypress/globals': true,
+  },
+}

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,37 +1,13 @@
 // @TODO Divide Base Config from 'Rules' Configs
 module.exports = {
-  extends: [
-    // Min to Keep
-    'airbnb-base',
-    // Jest plugin - write jest testing for all packages
-    'plugin:jest/recommended',
-    // Abstract Vue to @phase2/eslint-config-vue
-    'plugin:vue/recommended',
-    // Prettier plugin - belongs to base
-    'plugin:prettier/recommended',
-    // Abstract Vue to @phase2/eslint-config-vue
-    'prettier/vue',
-  ],
-  // Keep for Base
+  extends: ['airbnb-base', 'plugin:prettier/recommended'],
   plugins: ['prettier'],
-  // Remove from Base, Project should config these directly.
-  root: true,
-  // Abstract globals to context sub-packages.
-  globals: {
-    // Abstract Drupal to @phase2/eslint-config-drupal
-    Drupal: true,
-    jQuery: true,
-    _: true,
-    // ???
-    BUILD_TARGET: true,
-  },
-  // ???
   env: {
     browser: true,
     node: true,
   },
-  // P2 only custom rule.
   rules: {
+    'no-console': 'warn',
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
   },
 }

--- a/packages/eslint-config/jest.js
+++ b/packages/eslint-config/jest.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['plugin:jest/recommended', './index.js'],
+  rules: {
+    'jest/expect-expect': 'off',
+  },
+}

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -26,9 +26,21 @@
   },
   "license": "GPL-2.0",
   "devDependencies": {
-    "eslint": "^7.2.0"
+    "eslint": "^7.2.0",
+    "prettier": "^2.0.5"
   },
   "peerDependencies": {
-    "eslint": "^7.2.0"
+    "eslint": "^7"
+  },
+  "dependencies": {
+    "@typescript-eslint/parser": "^3.6.0",
+    "eslint-config-airbnb": "^18.2.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-cypress": "^2.11.1",
+    "eslint-plugin-jest": "^23.18.0",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react": "^7.20.3",
+    "eslint-plugin-react-hooks": "^4.0.7"
   }
 }

--- a/packages/eslint-config/react.js
+++ b/packages/eslint-config/react.js
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: ['prettier/react', './index.js'],
+  rules: {
+    'react/jsx-filename-extension': 'off',
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
+  },
+}

--- a/packages/eslint-config/typescript.js
+++ b/packages/eslint-config/typescript.js
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: ['prettier/@typescript', './index.js'],
+  overrides: [
+    {
+      files: ['**/*.ts?(x)'],
+      parser: '@typescript-eslint/parser',
+      extends: [
+        'plugin:@typescript-eslint/recommended',
+        'prettier/@typescript-eslint',
+        'plugin:import/typescript',
+      ],
+    },
+  ],
+}

--- a/packages/eslint-config/vue.js
+++ b/packages/eslint-config/vue.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['plugin:vue/recommended', 'prettier/vue', './index.js'],
+}


### PR DESCRIPTION
# Adding shareable eslint rules

## Issue Description

This PR attempts to set up the particle codebase to utilize shareable eslint configs.

To use the configs one should only need to do the following for their `.eslintrc.js`

### Base eslint rules
```
module.exports = {
  extends: ['@phase2/eslint-config']
}
```

### React eslint rules
```
module.exports = {
  extends: ['@phase2/eslint-config/react', '@phase2/eslint-config/typescript']
}
```

## Summary of Changes

Split up the eslint files to be used individually or combined together
