### PR TITLE
bug: update particle namespace and update details class

### DIFF
--- a/apps/drupal-default/particle_theme/includes/misc.theme.inc
+++ b/apps/drupal-default/particle_theme/includes/misc.theme.inc
@@ -5,7 +5,7 @@
  * Functions to support theming miscellaneous things the Particle theme.
  */
 
-use Drupal\theme\custom\Particle\Particle;
+use Drupal\Particle\Particle;
 
 /**
  * Implements hook_preprocess().
@@ -33,12 +33,4 @@ function particle_page_attachments_alter(array &$page) {
     ],
   ];
   $page['#attached']['html_head'][] = [$ie_edge, 'ie_edge'];
-}
-
-/**
- * Implements hook_preprocess_details().
- */
-function particle_preprocess_details(array &$variables) {
-  $variables['attributes']['class'][] = 'details';
-  $variables['summary_attributes']['class'] = 'summary';
 }

--- a/apps/drupal-default/particle_theme/templates/form/details.html.twig
+++ b/apps/drupal-default/particle_theme/templates/form/details.html.twig
@@ -15,16 +15,12 @@
  * @see template_preprocess_details()
  */
 #}
-<details{{ attributes.addClass(['details']) }}>
-  {%
-    set summary_classes = [
-      'summary',
-      required ? 'js-form-required',
-      required ? 'form-required',
-    ]
-  %}
+<details {{ attributes.addClass(['details']) }}>
+  {% set summary_classes = ['summary', required ? 'js-form-required', required ? 'form-required'] %}
   {%- if title -%}
-    <summary{{ summary_attributes.addClass(summary_classes) }}>{{ title }}</summary>
+    <summary {{ summary_attributes.addClass(summary_classes) }}>
+      {{ title }}
+    </summary>
   {%- endif -%}
 
   {% if errors %}

--- a/apps/drupal-default/particle_theme/templates/form/details.html.twig
+++ b/apps/drupal-default/particle_theme/templates/form/details.html.twig
@@ -1,0 +1,39 @@
+{#
+/**
+ * @file
+ * Theme override for a details element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the details element.
+ * - errors: (optional) Any errors for this details element, may not be set.
+ * - title: (optional) The title of the element, may not be set.
+ * - summary_attributes: A list of HTML attributes for the summary element.
+ * - description: (optional) The description of the element, may not be set.
+ * - children: (optional) The children of the element, may not be set.
+ * - value: (optional) The value of the element, may not be set.
+ *
+ * @see template_preprocess_details()
+ */
+#}
+<details{{ attributes.addClass(['details']) }}>
+  {%
+    set summary_classes = [
+      'summary',
+      required ? 'js-form-required',
+      required ? 'form-required',
+    ]
+  %}
+  {%- if title -%}
+    <summary{{ summary_attributes.addClass(summary_classes) }}>{{ title }}</summary>
+  {%- endif -%}
+
+  {% if errors %}
+    <div>
+      {{ errors }}
+    </div>
+  {% endif %}
+
+  {{ description }}
+  {{ children }}
+  {{ value }}
+</details>

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,18 @@
 {
-    "name": "phase2/particle",
-    "description": "A system of tools to build design systems in Pattern Lab for Drupal and Grav.",
-    "type": "drupal-custom-theme",
-    "license": "GPL-2.0",
-    "homepage": "https://github.com/phase2/particle",
-    "authors": [
-        {
-            "name": "Christopher Bloom (illepic)",
-            "email": "bloomcb@gmail.com"
-        }
-    ],
-    "support": {
-        "docs": "https://phase2.github.io/frontend-docs/",
-        "issues": "https://github.com/phase2/particle/issues",
-        "source": "https://github.com/phase2/particle/tree/master"
+  "name": "phase2/particle",
+  "description": "A system of tools to build design systems in Pattern Lab for Drupal.",
+  "type": "drupal-custom-theme",
+  "license": "GPL-2.0",
+  "homepage": "https://github.com/phase2/particle",
+  "authors": [
+    {
+      "name": "Christopher Bloom (illepic)",
+      "email": "bloomcb@gmail.com"
     }
+  ],
+  "support": {
+    "docs": "https://phase2.github.io/frontend-docs/",
+    "issues": "https://github.com/phase2/particle/issues",
+    "source": "https://github.com/phase2/particle/tree/master"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "authors": [
     {
       "name": "Christopher Bloom (illepic)",
-      "email": "bloomcb@gmail.com"
+      "email": "cbloom@phase2technology.com"
     }
   ],
   "support": {


### PR DESCRIPTION
# Pull Request

Closes Issue #no-issue

## Issue Description

* Update incorrect namespace in misc.theme.inc
* Remove summary_attributes hard override
* Add details element template

## Summary of Changes

Fixes whitescreen error for misc.theme.inc namespace use.
Fixes hard override of summary to summary_attributes, preventing those attributes being overridden or overrun. 