### PR TITLE
Saving options in .particle-rc

### DIFF
--- a/packages/generator-particle-base/src/generators/app/index.ts
+++ b/packages/generator-particle-base/src/generators/app/index.ts
@@ -19,12 +19,10 @@ module.exports = class extends Generator {
   // configuration will come from the constructor argument
   configuration: Answers
   packageJson: Record<string, any>
-  cliVersion: string
+  cliVersion = ''
 
   constructor(args: any, opts: any) {
     super(args, opts)
-    console.log(args)
-    this.cliVersion = ''
     for (let i = 0; i < args.length; i++) {
       const value = args[i]
       const regex = /(cli-version=)(\d.*)/

--- a/packages/generator-particle-base/src/generators/app/index.ts
+++ b/packages/generator-particle-base/src/generators/app/index.ts
@@ -19,9 +19,20 @@ module.exports = class extends Generator {
   // configuration will come from the constructor argument
   configuration: Answers
   packageJson: Record<string, any>
+  cliVersion: string
 
   constructor(args: any, opts: any) {
     super(args, opts)
+    console.log(args)
+    this.cliVersion = ''
+    for (let i = 0; i < args.length; i++) {
+      const value = args[i]
+      const regex = /(cli-version=)(\d.*)/
+      const matches = regex.exec(value)
+      if (matches) {
+        this.cliVersion = matches[2]
+      }
+    }
     // makes config a required argument
     this.option('configuration', {
       type: String,
@@ -82,7 +93,14 @@ module.exports = class extends Generator {
         options: configOptions[results.config],
       }
     }
-
+    fs.writeFileSync(
+      '.particle-rc',
+      JSON.stringify(
+        { ...this.configuration, ...{ 'cli-version': this.cliVersion } },
+        null,
+        2
+      )
+    )
     this.packageJson.name = results.projectName
   }
 

--- a/packages/generator-particle-base/src/generators/app/index.ts
+++ b/packages/generator-particle-base/src/generators/app/index.ts
@@ -75,6 +75,21 @@ module.exports = class extends Generator {
     )
   }
 
+  /**
+   * Creeate a particle config file
+   */
+
+  _writeParticleConfig() {
+    fs.writeFileSync(
+      '.particle-rc',
+      JSON.stringify(
+        { ...this.configuration, ...{ 'cli-version': this.cliVersion } },
+        null,
+        2
+      )
+    )
+  }
+
   async _promptUser() {
     // Initialize storybook
     const results: ConfigurationAnswers = await this.prompt(configurationPrompt)
@@ -93,14 +108,6 @@ module.exports = class extends Generator {
         options: configOptions[results.config],
       }
     }
-    fs.writeFileSync(
-      '.particle-rc',
-      JSON.stringify(
-        { ...this.configuration, ...{ 'cli-version': this.cliVersion } },
-        null,
-        2
-      )
-    )
     this.packageJson.name = results.projectName
   }
 
@@ -129,6 +136,7 @@ module.exports = class extends Generator {
 
   writing() {
     this._createPackageJson()
+    this._writeParticleConfig()
 
     // Installs all dependencies
     this.npmInstall()

--- a/packages/particle-cli/bin/particle-cli.ts
+++ b/packages/particle-cli/bin/particle-cli.ts
@@ -16,9 +16,17 @@ program
   .description('Scaffold your project from a set of prompts.')
   .action(function () {
     // runs yeoman under the hood and resolves the yeoman module directly
-    spawn('yo', [require.resolve('@phase2/generator-particle-base')], {
-      stdio: 'inherit',
-    })
+    spawn(
+      'yo',
+      [
+        require.resolve('@phase2/generator-particle-base'),
+        `cli-version=${pkg.version}`,
+        'example-arg',
+      ],
+      {
+        stdio: 'inherit',
+      }
+    )
   })
 
 // allow commander to parse `process.argv`


### PR DESCRIPTION
# Pull Request

Closes Issue #919

## Issue Description

This PR adds saves the user's inputs in an `.particle-rc` file that includes the configuration options that the user has selected as well as the version of the cli that the user executed the command from.

## Summary of Changes

After the user is prompted for answers, we take those answers as well as the cli version and save it into a `.particle-rc` file.
